### PR TITLE
Add layers and csolution

### DIFF
--- a/Layer/App/Validation_FreeRTOS/App.clayer.yml
+++ b/Layer/App/Validation_FreeRTOS/App.clayer.yml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: App
+  # name: CMSIS-RTOS2_Validation
+  description: Validation of CMSIS-RTOS2 FreeRTOS implementation
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: ARM::CMSIS-FreeRTOS
+
+  defines:
+    - PRINT_XML_REPORT=1
+  
+  add-paths:
+    - ../../Include
+    - ./RTE/CMSIS_RTOS2_Validation
+
+  misc:
+    - C*:
+      - -Wno-macro-redefined
+      - -Wno-pragma-pack
+      - -Wno-parentheses-equality
+
+  components:
+    # [Cvendor::]Cclass[&Cbundle]:Cgroup[:Csub][&Cvariant][@[>=]Cversion]
+    - component: ARM::CMSIS:RTOS2:FreeRTOS&Cortex-M
+
+    - component: ARM::RTOS&FreeRTOS:Config&CMSIS RTOS2
+    - component: ARM::RTOS&FreeRTOS:Core&Cortex-M
+    - component: ARM::RTOS&FreeRTOS:Event Groups
+    - component: ARM::RTOS&FreeRTOS:Heap&Heap_4
+    - component: ARM::RTOS&FreeRTOS:Stream Buffer
+    - component: ARM::RTOS&FreeRTOS:Timers
+
+  groups:
+    - group: Documentation
+      files:
+        - file: ../../README.md
+
+    - group: Source files
+      files:
+        - file: ./main.c 
+        - file: ./retarget_stdio.c
+
+    - group: CMSIS-RTOS2_Validation
+      files:
+        - file: ../../Source/cmsis_rv2.c
+        - file: ../../Source/RV2_Kernel.c
+        - file: ../../Source/RV2_Thread.c
+        - file: ../../Source/RV2_ThreadFlags.c
+        - file: ../../Source/RV2_GenWait.c
+        - file: ../../Source/RV2_Timer.c
+        - file: ../../Source/RV2_EventFlags.c
+        - file: ../../Source/RV2_Mutex.c
+        - file: ../../Source/RV2_Semaphore.c
+        - file: ../../Source/RV2_MemoryPool.c
+        - file: ../../Source/RV2_MessageQueue.c
+        - file: ../../Source/RV2_Common.c
+        - file: ./RTE/CMSIS_RTOS2_Validation/RV2_Config.c
+        - file: ./RTE/CMSIS_RTOS2_Validation/RV2_Config.h
+    
+    - group: Validation Framework
+      files:
+        - file: ../../Source/tf_main.c
+        - file: ../../Source/tf_report.c

--- a/Layer/App/Validation_FreeRTOS/RTE/CMSIS_RTOS2_Validation/RV2_Config.c
+++ b/Layer/App/Validation_FreeRTOS/RTE/CMSIS_RTOS2_Validation/RV2_Config.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cmsis_rv2.h"
+#include "RV2_Config_Device.h"
+
+#if defined(__CORTEX_A)
+#include "irq_ctrl.h"
+#endif
+
+/* Prototypes */
+void TST_IRQ_HANDLER_A (void);
+void TST_IRQ_HANDLER_B (void);
+void (*TST_IRQHandler_A)(void);
+void (*TST_IRQHandler_B)(void);
+
+extern int stdout_putchar (int ch);
+
+/*
+  Primary interrupt handler
+*/
+void TST_IRQ_HANDLER_A (void) {
+
+  if (TST_IRQHandler_A != NULL) {
+    TST_IRQHandler_A();
+  }
+}
+
+/*
+  Secondary interrupt handler
+*/
+void TST_IRQ_HANDLER_B (void) {
+
+  if (TST_IRQHandler_B != NULL) {
+    TST_IRQHandler_B();
+  }
+}
+
+/*
+  Test suite initialization
+*/
+void TS_Init (void) {
+
+#if defined(__CORTEX_M)
+  /* Set primary and secondary interrupt priority */
+  NVIC_SetPriority ((IRQn_Type)TST_IRQ_NUM_A, 5U);
+  NVIC_SetPriority ((IRQn_Type)TST_IRQ_NUM_B, 4U);
+
+  /* Enable interrupts */
+  NVIC_EnableIRQ((IRQn_Type)TST_IRQ_NUM_A);
+  NVIC_EnableIRQ((IRQn_Type)TST_IRQ_NUM_B);
+
+#elif defined(__CORTEX_A)
+  /* Disable interrupts and clear potential pending bits */
+  IRQ_Disable ((IRQn_ID_t)TST_IRQ_NUM_A);
+  IRQ_Disable ((IRQn_ID_t)TST_IRQ_NUM_B);
+
+  IRQ_ClearPending ((IRQn_ID_t)TST_IRQ_NUM_A);
+  IRQ_ClearPending ((IRQn_ID_t)TST_IRQ_NUM_B);
+
+  /* Set edge-triggered IRQ */
+  IRQ_SetMode ((IRQn_ID_t)TST_IRQ_NUM_A, IRQ_MODE_TRIG_EDGE);
+  IRQ_SetMode ((IRQn_ID_t)TST_IRQ_NUM_B, IRQ_MODE_TRIG_EDGE);
+
+  /* Register interrupt handlers */
+  IRQ_SetHandler((IRQn_ID_t)TST_IRQ_NUM_A, TST_IRQ_HANDLER_A);
+  IRQ_SetHandler((IRQn_ID_t)TST_IRQ_NUM_B, TST_IRQ_HANDLER_B);
+
+  /* Enable interrupts */
+  IRQ_Enable((IRQn_ID_t)TST_IRQ_NUM_A);
+  IRQ_Enable((IRQn_ID_t)TST_IRQ_NUM_B);
+#endif
+}
+
+/*
+  Test suite de-initialization
+*/
+void TS_Uninit (void) {
+  /* Close debug session here */
+
+  /* Note:
+     VHT model shall have parameter shutdown_on_eot set to true.
+     Simulation is then shutdown when EOT, ASCII4, character is
+     transmitted via UART.
+   */
+  stdout_putchar (0x04);
+}
+
+/*
+  Enable interrupt trigger in the IRQ controller.
+*/
+void EnableIRQ (int32_t irq_num) {
+
+  if (irq_num == IRQ_A) {
+    irq_num = TST_IRQ_NUM_A;
+  } else {
+    irq_num = TST_IRQ_NUM_B;
+  }
+
+#if defined(__CORTEX_M)
+  NVIC_EnableIRQ((IRQn_Type)irq_num);
+#elif defined(__CORTEX_A)
+  IRQ_Enable((IRQn_ID_t)irq_num);
+#endif
+}
+
+/*
+  Disable interrupt trigger in the IRQ controller.
+*/
+void DisableIRQ (int32_t irq_num) {
+
+  if (irq_num == IRQ_A) {
+    irq_num = TST_IRQ_NUM_A;
+  } else {
+    irq_num = TST_IRQ_NUM_B;
+  }
+
+#if defined(__CORTEX_M)
+  NVIC_DisableIRQ((IRQn_Type)irq_num);
+#elif defined(__CORTEX_A)
+  IRQ_Disable((IRQn_ID_t)irq_num);
+#endif
+}
+
+/*
+  Set pending interrupt in the IRQ controller.
+*/
+void SetPendingIRQ (int32_t irq_num) {
+
+  if (irq_num == IRQ_A) {
+    irq_num = TST_IRQ_NUM_A;
+  } else {
+    irq_num = TST_IRQ_NUM_B;
+  }
+
+#if defined(__CORTEX_M)
+  NVIC_SetPendingIRQ((IRQn_Type)irq_num);
+
+  __DSB();
+  __ISB();
+  __DMB();
+
+  while (NVIC_GetPendingIRQ((IRQn_Type)irq_num) != 0);
+
+#elif defined(__CORTEX_A)
+  __disable_irq();
+  IRQ_SetPending((IRQn_ID_t)irq_num);
+  __enable_irq();
+
+  __DSB();
+  __ISB();
+  __DMB();
+
+  while (IRQ_GetPending((IRQn_ID_t)irq_num) != 0);
+#endif
+}

--- a/Layer/App/Validation_FreeRTOS/RTE/CMSIS_RTOS2_Validation/RV2_Config.h
+++ b/Layer/App/Validation_FreeRTOS/RTE/CMSIS_RTOS2_Validation/RV2_Config.h
@@ -1,0 +1,414 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_H__
+#define RV2_CONFIG_H__
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <h> CMSIS-RTOS2 Test Suite Configuration
+//   <o>Test Runner Thread Stack size <128-16384>
+//   <i> Defines stack size for test runner thread.
+//   <i> Default: 1024
+#define MAIN_THREAD_STACK                 1024
+
+// <o> Tick Timer Interval [us] <1-1000000>
+// <i> Defines kernel tick timer interval value.
+// <i> Default: 1000
+#define RTOS2_TICK_FREQ                   1000
+
+// <h> Object Implementation Specific Configuration
+// <o> Maximum Thread Flags
+// <i> Maximum number of Thread Flags available per Thread object
+#define MAX_THREADFLAGS_CNT               31
+// <o> Maximum Event Flags
+// <i> Maximum number of Event Flags available per Event Flags object
+#define MAX_EVENTFLAGS_CNT                24
+// <o> Maximum Mutex Locks
+// <i> Maximum number of recursive Mutex locks per Mutex object
+#define MAX_MUTEX_LOCK_CNT                255
+// <o> Maximum Semaphore Tokens
+// <i> Maximum number of available tokens per Semaphore object
+#define MAX_SEMAPHORE_TOKEN_CNT           255
+// </h>
+
+// <h> Disable Test Cases
+// <i> Uncheck to disable an individual test case
+//   <e0>Kernel Information and Control
+//     <q01>TC_osKernelInitialize_1
+//     <q02>TC_osKernelGetInfo_1
+//     <q03>TC_osKernelGetState_1
+//     <q04>TC_osKernelGetState_2
+//     <q05>TC_osKernelStart_1
+//     <q06>TC_osKernelLock_1
+//     <q07>TC_osKernelLock_2
+//     <q08>TC_osKernelUnlock_1
+//     <q09>TC_osKernelUnlock_2
+//     <q10>TC_osKernelRestoreLock_1
+//     <q11>TC_osKernelSuspend_1
+//     <q12>TC_osKernelResume_1
+//     <q13>TC_osKernelGetTickCount_1
+//     <q14>TC_osKernelGetTickFreq_1
+//     <q15>TC_osKernelGetSysTimerCount_1
+//     <q16>TC_osKernelGetSysTimerFreq_1
+#define TC_OSKERNEL_EN                    1
+#define TC_OSKERNELINITIALIZE_1_EN        1
+#define TC_OSKERNELGETINFO_1_EN           1
+#define TC_OSKERNELGETSTATE_1_EN          1
+#define TC_OSKERNELGETSTATE_2_EN          0
+#define TC_OSKERNELSTART_1_EN             1
+#define TC_OSKERNELLOCK_1_EN              1
+#define TC_OSKERNELLOCK_2_EN              0
+#define TC_OSKERNELUNLOCK_1_EN            1
+#define TC_OSKERNELUNLOCK_2_EN            0
+#define TC_OSKERNELRESTORELOCK_1_EN       1
+#define TC_OSKERNELSUSPEND_1_EN           0
+#define TC_OSKERNELRESUME_1_EN            0
+#define TC_OSKERNELGETTICKCOUNT_EN        1
+#define TC_OSKERNELGETTICKFREQ_EN         1
+#define TC_OSKERNELGETSYSTIMERCOUNT_EN    1
+#define TC_OSKERNELGETSYSTIMERFREQ_EN     1
+//   </e>
+
+//   <e0>Thread Management
+//     <q01>TC_osThreadNew_1
+//     <q02>TC_osThreadNew_2
+//     <q03>TC_osThreadNew_3
+//     <q04>TC_osThreadNew_4
+//     <q05>TC_osThreadNew_5
+//     <q06>TC_osThreadNew_6
+//     <q07>TC_osThreadNew_7
+//     <q08>TC_osThreadGetName_1
+//     <q09>TC_osThreadGetId_1
+//     <q10>TC_osThreadGetState_1
+//     <q11>TC_osThreadGetState_2
+//     <q12>TC_osThreadGetState_3
+//     <q13>TC_osThreadSetPriority_1
+//     <q14>TC_osThreadSetPriority_2
+//     <q15>TC_osThreadGetPriority_1
+//     <q16>TC_osThreadYield_1
+//     <q17>TC_osThreadSuspend_1
+//     <q18>TC_osThreadResume_1
+//     <q19>TC_osThreadDetach_1
+//     <q20>TC_osThreadDetach_2
+//     <q21>TC_osThreadJoin_1
+//     <q22>TC_osThreadJoin_2
+//     <q23>TC_osThreadJoin_3
+//     <q24>TC_osThreadExit_1
+//     <q25>TC_osThreadTerminate_1
+//     <q26>TC_osThreadGetStackSize_1
+//     <q27>TC_osThreadGetStackSpace_1
+//     <q28>TC_osThreadGetCount_1
+//     <q29>TC_osThreadEnumerate_1
+//     <q30>TC_ThreadNew
+//     <q31>TC_ThreadMultiInstance
+//     <q32>TC_ThreadTerminate
+//     <q33>TC_ThreadRestart
+//     <q34>TC_ThreadPriorityExec
+//     <q35>TC_ThreadYield
+//     <q36>TC_ThreadSuspendResume
+//     <q37>TC_ThreadReturn
+//     <q38>TC_ThreadAllocation
+#define TC_OSTHREAD_EN                    1
+#define TC_OSTHREADNEW_1_EN               1
+#define TC_OSTHREADNEW_2_EN               1
+#define TC_OSTHREADNEW_3_EN               0
+#define TC_OSTHREADNEW_4_EN               1
+#define TC_OSTHREADNEW_5_EN               1
+#define TC_OSTHREADNEW_6_EN               1
+#define TC_OSTHREADNEW_7_EN               1
+#define TC_OSTHREADGETNAME_1_EN           1
+#define TC_OSTHREADGETID_1_EN             1
+#define TC_OSTHREADGGETSTATE_1_EN         1
+#define TC_OSTHREADGGETSTATE_2_EN         1
+#define TC_OSTHREADGGETSTATE_3_EN         0
+#define TC_OSTHREADSETPRIORITY_1_EN       1
+#define TC_OSTHREADSETPRIORITY_2_EN       1
+#define TC_OSTHREADGETPRIORITY_1_EN       1
+#define TC_OSTHREADYIELD_1_EN             1
+#define TC_OSTHREADSUSPEND_1_EN           1
+#define TC_OSTHREADRESUME_1_EN            1
+#define TC_OSTHREADDETACH_1_EN            0
+#define TC_OSTHREADDETACH_2_EN            0
+#define TC_OSTHREADJOIN_1_EN              0
+#define TC_OSTHREADJOIN_2_EN              0
+#define TC_OSTHREADJOIN_3_EN              0
+#define TC_OSTHREADEXIT_1_EN              1
+#define TC_OSTHREADTERMINATE_1_EN         1
+#define TC_OSTHREADGETSTACKSIZE_1_EN      0
+#define TC_OSTHREADGETSTACKSPACE_1_EN     1
+#define TC_OSTHREADGETCOUNT_1_EN          1
+#define TC_OSTHREADENUMERATE_1_EN         1
+#define TC_THREADNEW_EN                   1
+#define TC_THREADMULTIINSTANCE_EN         1
+#define TC_THREADTERMINATE_EN             1
+#define TC_THREADRESTART_EN               1
+#define TC_THREADPRIORITYEXEC_EN          1
+#define TC_THREADYIELD_EN                 1
+#define TC_THREADSUSPENDRESUME_EN         1
+#define TC_THREADRETURN_EN                0
+#define TC_THREADALLOCATION_EN            1
+//   </e>
+
+//   <e0>Thread Flags
+//     <q01>TC_ThreadFlagsMainThread,
+//     <q02>TC_ThreadFlagsChildThread,
+//     <q03>TC_ThreadFlagsChildToParent
+//     <q04>TC_ThreadFlagsChildToChild
+//     <q05>TC_ThreadFlagsWaitTimeout
+//     <q06>TC_ThreadFlagsCheckTimeout
+//     <q07>TC_ThreadFlagsParam
+//     <q08>TC_ThreadFlagsInterrupts
+#define TC_OSTHREADFLAGS_EN               1
+#define TC_THREADFLAGSMAINTHREAD_EN       1
+#define TC_THREADFLAGSCHILDTHREAD_EN      1
+#define TC_THREADFLAGSCHILDTOPARENT_EN    1
+#define TC_THREADFLAGSCHILDTOCHILD_EN     1
+#define TC_THREADFLAGSWAITTIMEOUT_EN      1
+#define TC_THREADFLAGSCHECKTIMEOUT_EN     1
+#define TC_THREADFLAGSPARAM_EN            1
+#define TC_THREADFLAGSINTERRUPTS_EN       1
+//   </e>
+
+//   <e0>Generic Wait Functions
+//     <q01>TC_GenWaitBasic
+//     <q02>TC_GenWaitInterrupts
+#define TC_OSDELAY_EN                     1
+#define TC_GENWAITBASIC_EN                1
+#define TC_GENWAITINTERRUPTS_EN           1
+//   </e>
+
+//   <e0>Timer Management
+//     <q01>TC_osTimerNew_1
+//     <q02>TC_osTimerNew_2
+//     <q03>TC_osTimerNew_3
+//     <q04>TC_osTimerGetName_1
+//     <q05>TC_osTimerStart_1
+//     <q06>TC_osTimerStop_1
+//     <q07>TC_osTimerStop_2
+//     <q08>TC_osTimerIsRunning_1
+//     <q09>TC_osTimerDelete_1
+//     <q10>TC_TimerAllocation
+//     <q11>TC_TimerOneShot
+//     <q12>TC_TimerPeriodic
+#define TC_OSTIMER_EN                     1
+#define TC_OSTIMERNEW_1_EN                1
+#define TC_OSTIMERNEW_2_EN                1
+#define TC_OSTIMERNEW_3_EN                1
+#define TC_OSTIMERGETNAME_1_EN            1
+#define TC_OSTIMERSTART_1_EN              1
+#define TC_OSTIMERSTOP_1_EN               1
+#define TC_OSTIMERSTOP_2_EN               1
+#define TC_OSTIMERISRUNNING_1_EN          1
+#define TC_OSTIMERDELETE_1_EN             1
+#define TC_TIMERONESHOT_EN                1
+#define TC_TIMERPERIODIC_EN               1
+#define TC_TIMERALLOCATION_EN             1
+//   </e>
+
+//   <e0>Event Flags
+//     <q01>TC_osEventFlagsNew_1
+//     <q02>TC_osEventFlagsNew_2
+//     <q03>TC_osEventFlagsNew_3
+//     <q04>TC_osEventFlagsSet_1
+//     <q05>TC_osEventFlagsClear_1
+//     <q06>TC_osEventFlagsGet_1
+//     <q07>TC_osEventFlagsWait_1
+//     <q08>TC_osEventFlagsDelete_1
+//     <q09>TC_osEventFlagsGetName_1
+//     <q00>TC_EventFlagsAllocation,
+//     <q11>TC_EventFlagsInterThreads,
+//     <q12>TC_EventFlagsCheckTimeout,
+//     <q13>TC_EventFlagsWaitTimeout,
+//     <q14>TC_EventFlagsDeleteWaiting
+#define TC_OSEVENTFLAGS_EN                1
+#define TC_OSEVENTFLAGSNEW_1_EN           1
+#define TC_OSEVENTFLAGSNEW_2_EN           1
+#define TC_OSEVENTFLAGSNEW_3_EN           1
+#define TC_OSEVENTFLAGSSET_1_EN           0
+#define TC_OSEVENTFLAGSCLEAR_1_EN         0
+#define TC_OSEVENTFLAGSGET_1_EN           1
+#define TC_OSEVENTFLAGSWAIT_1_EN          0
+#define TC_OSEVENTFLAGSDELETE_1_EN        1
+#define TC_OSEVENTFLAGSGETNAME_1_EN       0
+#define TC_EVENTFLAGSALLOCATION_EN        1
+#define TC_EVENTFLAGSINTERTHREADS_EN      1
+#define TC_EVENTFLAGSCHECKTIMEOUT_EN      1
+#define TC_EVENTFLAGSWAITTIMEOUT_EN       1
+#define TC_EVENTFLAGSDELETEWAITING_EN     1
+//   </e>
+
+//   <e0>Mutex Management
+//     <q01>TC_osMutexNew_1
+//     <q02>TC_osMutexNew_2
+//     <q03>TC_osMutexNew_3
+//     <q04>TC_osMutexNew_4
+//     <q05>TC_osMutexNew_5
+//     <q06>TC_osMutexNew_6
+//     <q07>TC_osMutexGetName_1
+//     <q08>TC_osMutexAcquire_1
+//     <q09>TC_osMutexAcquire_2
+//     <q10>TC_osMutexRelease_1
+//     <q11>TC_osMutexGetOwner_1
+//     <q12>TC_osMutexDelete_1
+//     <q13>TC_MutexAllocation
+//     <q14>TC_MutexCheckTimeout
+//     <q15>TC_MutexRobust
+//     <q16>TC_MutexPrioInherit
+//     <q17>TC_MutexNestedAcquire
+//     <q18>TC_MutexPriorityInversion
+//     <q19>TC_MutexOwnership
+#define TC_OSMUTEX_EN                     1
+#define TC_OSMUTEXNEW_1_EN                1
+#define TC_OSMUTEXNEW_2_EN                1
+#define TC_OSMUTEXNEW_3_EN                1
+#define TC_OSMUTEXNEW_4_EN                0
+#define TC_OSMUTEXNEW_5_EN                1
+#define TC_OSMUTEXNEW_6_EN                1
+#define TC_OSMUTEXGETNAME_1_EN            0
+#define TC_OSMUTEXACQUIRE_1_EN            1
+#define TC_OSMUTEXACQUIRE_2_EN            1
+#define TC_OSMUTEXRELEASE_1_EN            1
+#define TC_OSMUTEXGETOWNER_1_EN           1
+#define TC_OSMUTEXDELETE_1_EN             1
+#define TC_MUTEXALLOCATION_EN             1
+#define TC_MUTEXCHECKTIMEOUT_EN           1
+#define TC_MUTEXROBUST_EN                 0
+#define TC_MUTEXPRIOINHERIT_EN            1
+#define TC_MUTEXNESTEDACQUIRE_EN          1
+#define TC_MUTEXPRIORITYINVERSION_EN      1
+#define TC_MUTEXOWNERSHIP_EN              0
+//   </e>
+
+//   <e0>Semaphores
+//     <q01>TC_osSemaphoreNew_1
+//     <q02>TC_osSemaphoreNew_2
+//     <q03>TC_osSemaphoreNew_3
+//     <q04>TC_osSemaphoreGetName_1
+//     <q05>TC_osSemaphoreAcquire_1
+//     <q06>TC_osSemaphoreRelease_1
+//     <q07>TC_osSemaphoreGetCount_1
+//     <q08>TC_osSemaphoreDelete_1
+//     <q09>TC_SemaphoreAllocation
+//     <q00>TC_SemaphoreCreateAndDelete
+//     <q11>TC_SemaphoreObtainCounting
+//     <q12>TC_SemaphoreObtainBinary
+//     <q13>TC_SemaphoreWaitForBinary
+//     <q14>TC_SemaphoreWaitForCounting
+//     <q15>TC_SemaphoreZeroCount
+//     <q16>TC_SemaphoreWaitTimeout
+//     <q17>TC_SemaphoreCheckTimeout
+#define TC_OSSEMAPHORE_EN                 1
+#define TC_OSSEMAPHORENEW_1_EN            1
+#define TC_OSSEMAPHORENEW_2_EN            1
+#define TC_OSSEMAPHORENEW_3_EN            1
+#define TC_OSSEMAPHOREGETNAME_1_EN        0
+#define TC_OSSEMAPHOREACQUIRE_1_EN        1
+#define TC_OSSEMAPHORERELEASE_1_EN        1
+#define TC_OSSEMAPHOREGETCOUNT_1_EN       1
+#define TC_OSSEMAPHOREDELETE_1_EN         1
+#define TC_SEMAPHOREALLOCATION_EN         1
+#define TC_SEMAPHORECREATEANDDELETE_EN    1
+#define TC_SEMAPHOREOBTAINCOUNTING_EN     1
+#define TC_SEMAPHOREOBTAINBINARY_EN       1
+#define TC_SEMAPHOREWAITFORBINARY_EN      1
+#define TC_SEMAPHOREWAITFORCOUNTING_EN    1
+#define TC_SEMAPHOREZEROCOUNT_EN          1
+#define TC_SEMAPHOREWAITTIMEOUT_EN        1
+#define TC_SEMAPHORECHECKTIMEOUT_EN       1
+//   </e>
+
+//   <e0>Memory Pool
+//     <q01>TC_osMemoryPoolNew_1
+//     <q02>TC_osMemoryPoolNew_2
+//     <q03>TC_osMemoryPoolNew_3
+//     <q04>TC_osMemoryPoolGetName_1
+//     <q05>TC_osMemoryPoolAlloc_1
+//     <q06>TC_osMemoryPoolFree_1
+//     <q07>TC_osMemoryPoolGetCapacity_1
+//     <q08>TC_osMemoryPoolGetBlockSize_1
+//     <q09>TC_osMemoryPoolGetCount_1
+//     <q00>TC_osMemoryPoolGetSpace_1
+//     <q11>TC_osMemoryPoolDelete_1
+//     <q12>TC_MemPoolAllocation
+//     <q13>TC_MemPoolAllocAndFree
+//     <q14>TC_MemPoolAllocAndFreeComb
+//     <q15>TC_MemPoolZeroInit
+#define TC_OSMEMORYPOOL_EN                1
+#define TC_OSMEMORYPOOLNEW_1_EN           1
+#define TC_OSMEMORYPOOLNEW_2_EN           1
+#define TC_OSMEMORYPOOLNEW_3_EN           1
+#define TC_OSMEMORYPOOLGETNAME_1_EN       1
+#define TC_OSMEMORYPOOLALLOC_1_EN         1
+#define TC_OSMEMORYPOOLFREE_1_EN          1
+#define TC_OSMEMORYPOOLGETCAPACITY_1_EN   1
+#define TC_OSMEMORYPOOLGETBLOCKSIZE_1_EN  1
+#define TC_OSMEMORYPOOLGETCOUNT_1_EN      1
+#define TC_OSMEMORYPOOLGETSPACE_1_EN      1
+#define TC_OSMEMORYPOOLDELETE_1_EN        1
+#define TC_MEMPOOLALLOCATION_EN           1
+#define TC_MEMPOOLALLOCANDFREE_EN         1
+#define TC_MEMPOOLALLOCANDFREECOMB_EN     1
+#define TC_MEMPOOLZEROINIT_EN             1
+//   </e>
+
+//   <e0>Message Queue
+//   <i>Exclude Message Queue test cases from the test suite
+//   <i>Message Queue test cases will not appear in test report
+//     <q01>TC_osMessageQueueNew_1
+//     <q02>TC_osMessageQueueNew_2
+//     <q03>TC_osMessageQueueNew_3
+//     <q04>TC_osMessageQueueGetName_1
+//     <q05>TC_osMessageQueuePut_1
+//     <q06>TC_osMessageQueuePut_2
+//     <q07>TC_osMessageQueueGet_1
+//     <q08>TC_osMessageQueueGet_2
+//     <q09>TC_osMessageQueueGetCapacity_1
+//     <q10>TC_osMessageQueueGetMsgSize_1
+//     <q11>TC_osMessageQueueGetCount_1
+//     <q12>TC_osMessageQueueGetSpace_1
+//     <q13>TC_osMessageQueueReset_1
+//     <q14>TC_osMessageQueueDelete_1
+//     <q15>TC_MsgQAllocation
+//     <q16>TC_MsgQBasic
+//     <q17>TC_MsgQWait
+//     <q18>TC_MsgQCheckTimeout
+#define TC_OSMESSAGEQUEUE_EN              1
+#define TC_OSMESSAGEQUEUENEW_1_EN         1
+#define TC_OSMESSAGEQUEUENEW_2_EN         1
+#define TC_OSMESSAGEQUEUENEW_3_EN         1
+#define TC_OSMESSAGEQUEUEGETNAME_1_EN     0
+#define TC_OSMESSAGEQUEUEPUT_1_EN         1
+#define TC_OSMESSAGEQUEUEPUT_2_EN         1
+#define TC_OSMESSAGEQUEUEGET_1_EN         1
+#define TC_OSMESSAGEQUEUEGET_2_EN         1
+#define TC_OSMESSAGEQUEUEGETCAPACITY_1_EN 1
+#define TC_OSMESSAGEQUEUEGETMSGSIZE_1_EN  1
+#define TC_OSMESSAGEQUEUEGETCOUNT_1_EN    1
+#define TC_OSMESSAGEQUEUEGETSPACE_1_EN    1
+#define TC_OSMESSAGEQUEUERESET_1_EN       1
+#define TC_OSMESSAGEQUEUEDELETE_1_EN      1
+#define TC_MSGQALLOCATION_EN              1
+#define TC_MSGQBASIC_EN                   1
+#define TC_MSGQWAIT_EN                    1
+#define TC_MSGQCHECKTIMEOUT_EN            1
+//   </e>
+// </h>
+// </h>
+
+#endif /* RV2_CONFIG_H__ */

--- a/Layer/App/Validation_FreeRTOS/RTE/RTOS/FreeRTOSConfig.h
+++ b/Layer/App/Validation_FreeRTOS/RTE/RTOS/FreeRTOSConfig.h
@@ -1,0 +1,321 @@
+/* --------------------------------------------------------------------------
+ * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * --------------------------------------------------------------------------
+ *
+ * $Revision:   V10.3.0
+ *
+ * Project:     CMSIS-FreeRTOS
+ * Title:       FreeRTOS configuration definitions
+ *
+ * --------------------------------------------------------------------------*/
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+ *
+ * See http://www.freertos.org/a00110.html
+ *----------------------------------------------------------*/
+
+#if (defined(__ARMCC_VERSION) || defined(__GNUC__) || defined(__ICCARM__))
+#include <stdint.h>
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+#endif
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+//  <o>Minimal stack size [words] <0-65535>
+//  <i> Stack for idle task and default task stack in words.
+//  <i> Default: 128
+#ifndef configMINIMAL_STACK_SIZE
+#define configMINIMAL_STACK_SIZE                ((uint16_t)(128))
+#endif
+
+//  <o>Total heap size [bytes] <0-0xFFFFFFFF>
+//  <i> Heap memory size in bytes.
+//  <i> Default: 8192
+#ifndef configTOTAL_HEAP_SIZE
+#define configTOTAL_HEAP_SIZE                   ((size_t)8192)
+#endif
+
+//  <o>Kernel tick frequency [Hz] <0-0xFFFFFFFF>
+//  <i> Kernel tick rate in Hz.
+//  <i> Default: 1000
+#ifndef configTICK_RATE_HZ
+#define configTICK_RATE_HZ                      ((TickType_t)1000)
+#endif
+
+//  <o>Timer task stack depth [words] <0-65535>
+//  <i> Stack for timer task in words.
+//  <i> Default: 80
+#ifndef configTIMER_TASK_STACK_DEPTH
+#define configTIMER_TASK_STACK_DEPTH            80
+#endif
+
+//  <o>Timer task priority <0-56>
+//  <i> Timer task priority.
+//  <i> Default: 40 (High)
+#ifndef configTIMER_TASK_PRIORITY
+#define configTIMER_TASK_PRIORITY               40
+#endif
+
+//  <o>Timer queue length <0-1024>
+//  <i> Timer command queue length.
+//  <i> Default: 5
+#ifndef configTIMER_QUEUE_LENGTH
+#define configTIMER_QUEUE_LENGTH                5
+#endif
+
+//  <o>Preemption interrupt priority
+//  <i> Maximum priority of interrupts that are safe to call FreeRTOS API.
+//  <i> Default: 16
+#ifndef configMAX_SYSCALL_INTERRUPT_PRIORITY
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY    16
+#endif
+
+//  <q>Use time slicing
+//  <i> Enable setting to use timeslicing.
+//  <i> Default: 1
+#ifndef configUSE_TIME_SLICING
+#define configUSE_TIME_SLICING                  1
+#endif
+
+//  <q>Idle should yield
+//  <i> Control Yield behaviour of the idle task.
+//  <i> Default: 1
+#ifndef configIDLE_SHOULD_YIELD
+#define configIDLE_SHOULD_YIELD                 1
+#endif
+
+//  <o>Check for stack overflow
+//    <0=>Disable <1=>Method one <2=>Method two
+//  <i> Enable or disable stack overflow checking.
+//  <i> Callback function vApplicationStackOverflowHook implementation is required when stack checking is enabled.
+//  <i> Default: 0
+#ifndef configCHECK_FOR_STACK_OVERFLOW
+#define configCHECK_FOR_STACK_OVERFLOW          2
+#endif
+
+//  <q>Use idle hook
+//  <i> Enable callback function call on each idle task iteration.
+//  <i> Callback function vApplicationIdleHook implementation is required when idle hook is enabled.
+//  <i> Default: 0
+#ifndef configUSE_IDLE_HOOK
+#define configUSE_IDLE_HOOK                     0
+#endif
+
+//  <q>Use tick hook
+//  <i> Enable callback function call during each tick interrupt.
+//  <i> Callback function vApplicationTickHook implementation is required when tick hook is enabled.
+//  <i> Default: 0
+#ifndef configUSE_TICK_HOOK
+#define configUSE_TICK_HOOK                     0
+#endif
+
+//  <q>Use deamon task startup hook
+//  <i> Enable callback function call when timer service starts.
+//  <i> Callback function vApplicationDaemonTaskStartupHook implementation is required when deamon task startup hook is enabled.
+//  <i> Default: 0
+#ifndef configUSE_DAEMON_TASK_STARTUP_HOOK
+#define configUSE_DAEMON_TASK_STARTUP_HOOK      0
+#endif
+
+//  <q>Use malloc failed hook
+//  <i> Enable callback function call when out of dynamic memory.
+//  <i> Callback function vApplicationMallocFailedHook implementation is required when malloc failed hook is enabled.
+//  <i> Default: 0
+#ifndef configUSE_MALLOC_FAILED_HOOK
+#define configUSE_MALLOC_FAILED_HOOK            0
+#endif
+
+//  <o>Queue registry size
+//  <i> Define maximum number of queue objects registered for debug purposes.
+//  <i> The queue registry is used by kernel aware debuggers to locate queue and semaphore structures and display associated text names.
+//  <i> Default: 0
+#ifndef configQUEUE_REGISTRY_SIZE
+#define configQUEUE_REGISTRY_SIZE               0
+#endif
+
+// <h>Event Recorder configuration
+//  <i> Initialize and setup Event Recorder level filtering.
+//  <i> Settings have no effect when Event Recorder is not present.
+
+//  <q>Initialize Event Recorder
+//  <i> Initialize Event Recorder before FreeRTOS kernel start.
+//  <i> Default: 1
+#ifndef configEVR_INITIALIZE
+#define configEVR_INITIALIZE                    1
+#endif
+
+//  <e>Setup recording level filter
+//  <i> Enable configuration of FreeRTOS events recording level
+//  <i> Default: 1
+#ifndef configEVR_SETUP_LEVEL
+#define configEVR_SETUP_LEVEL                   1
+#endif
+
+//  <o>Tasks functions
+//  <i> Define event recording level bitmask for events generated from Tasks functions.
+//  <i> Default: 0x05
+//    <0x00=>Off <0x01=>Errors <0x05=>Errors + Operation <0x0F=>All
+#ifndef configEVR_LEVEL_TASKS
+#define configEVR_LEVEL_TASKS                   0x05
+#endif
+
+//  <o>Queue functions
+//  <i> Define event recording level bitmask for events generated from Queue functions.
+//  <i> Default: 0x05
+//    <0x00=>Off <0x01=>Errors <0x05=>Errors + Operation <0x0F=>All
+
+#ifndef configEVR_LEVEL_QUEUE
+#define configEVR_LEVEL_QUEUE                   0x05
+#endif
+
+//  <o>Timer functions
+//  <i> Define event recording level bitmask for events generated from Timer functions.
+//  <i> Default: 0x05
+//    <0x00=>Off <0x01=>Errors <0x05=>Errors + Operation <0x0F=>All
+#ifndef configEVR_LEVEL_TIMERS
+#define configEVR_LEVEL_TIMERS                  0x05
+#endif
+
+//  <o>Event Groups functions
+//  <i> Define event recording level bitmask for events generated from Event Groups functions.
+//  <i> Default: 0x05
+//    <0x00=>Off <0x01=>Errors <0x05=>Errors + Operation <0x0F=>All
+#ifndef configEVR_LEVEL_EVENTGROUPS
+#define configEVR_LEVEL_EVENTGROUPS             0x05
+#endif
+
+//  <o>Heap functions
+//  <i> Define event recording level bitmask for events generated from Heap functions.
+//  <i> Default: 0x05
+//    <0x00=>Off <0x01=>Errors <0x05=>Errors + Operation <0x0F=>All
+#ifndef configEVR_LEVEL_HEAP
+#define configEVR_LEVEL_HEAP                    0x05
+#endif
+
+//  <o>Stream Buffer functions
+//  <i> Define event recording level bitmask for events generated from Stream Buffer functions.
+//  <i> Default: 0x05
+//    <0x00=>Off <0x01=>Errors <0x05=>Errors + Operation <0x0F=>All
+#ifndef configEVR_LEVEL_STREAMBUFFER
+#define configEVR_LEVEL_STREAMBUFFER            0x05
+#endif
+//  </e>
+// </h>
+
+// <h> Port Specific Features
+// <i> Enable and configure port specific features.
+// <i> Check FreeRTOS documentation for definitions that apply for the used port.
+
+//  <q>Use Floating Point Unit
+//  <i> Using Floating Point Unit (FPU) affects context handling.
+//  <i> Enable FPU when application uses floating point operations.
+//  <i> Default: 1
+#ifndef configENABLE_FPU
+#define configENABLE_FPU                      1
+#endif
+
+//  <q>Use Memory Protection Unit
+//  <i> Using Memory Protection Unit (MPU) requires detailed memory map definition.
+//  <i> This setting is only releavant for MPU enabled ports.
+//  <i> Default: 0
+#ifndef configENABLE_MPU
+#define configENABLE_MPU                      0
+#endif
+
+//  <q> Use TrustZone Secure Side Only
+//  <i> This settings prevents FreeRTOS contex switch to Non-Secure side.
+//  <i> Enable this setting when FreeRTOS runs on the Secure side only.
+#ifndef configRUN_FREERTOS_SECURE_ONLY
+#define configRUN_FREERTOS_SECURE_ONLY        1
+#endif
+
+//  <q>Use TrustZone Security Extension
+//  <i> Using TrustZone affects context handling.
+//  <i> Enable TrustZone when FreeRTOS runs on the Non-Secure side and calls functions from the Secure side.
+//  <i> Default: 1
+#ifndef configENABLE_TRUSTZONE
+#define configENABLE_TRUSTZONE                0
+#endif
+
+//  <o>Minimal secure stack size [words] <0-65535>
+//  <i> Stack for idle task Secure side context in words.
+//  <i> This setting is only relevant when TrustZone extension is enabled.
+//  <i> Default: 128
+#ifndef configMINIMAL_SECURE_STACK_SIZE
+#define configMINIMAL_SECURE_STACK_SIZE       ((uint32_t)128)
+#endif
+// </h>
+
+//------------- <<< end of configuration section >>> ---------------------------
+
+/* Defines needed by FreeRTOS to implement CMSIS RTOS2 API. Do not change! */
+#define configCPU_CLOCK_HZ                      (SystemCoreClock)
+#define configSUPPORT_STATIC_ALLOCATION         1
+#define configSUPPORT_DYNAMIC_ALLOCATION        1
+#define configUSE_PREEMPTION                    1
+#define configUSE_TIMERS                        1
+#define configUSE_MUTEXES                       1
+#define configUSE_RECURSIVE_MUTEXES             1
+#define configUSE_COUNTING_SEMAPHORES           1
+#define configUSE_TASK_NOTIFICATIONS            1
+#define configUSE_TRACE_FACILITY                1
+#define configUSE_16_BIT_TICKS                  0
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+#define configMAX_PRIORITIES                    56
+#define configKERNEL_INTERRUPT_PRIORITY         255
+
+/* Defines that include FreeRTOS functions which implement CMSIS RTOS2 API. Do not change! */
+#define INCLUDE_xEventGroupSetBitsFromISR       1
+#define INCLUDE_xSemaphoreGetMutexHolder        1
+#define INCLUDE_vTaskDelay                      1
+#define INCLUDE_xTaskDelayUntil                 1
+#define INCLUDE_vTaskDelete                     1
+#define INCLUDE_xTaskGetCurrentTaskHandle       1
+#define INCLUDE_xTaskGetSchedulerState          1
+#define INCLUDE_uxTaskGetStackHighWaterMark     1
+#define INCLUDE_uxTaskPriorityGet               1
+#define INCLUDE_vTaskPrioritySet                1
+#define INCLUDE_eTaskGetState                   1
+#define INCLUDE_vTaskSuspend                    1
+#define INCLUDE_xTimerPendFunctionCall          1
+
+/* Map the FreeRTOS port interrupt handlers to their CMSIS standard names. */
+#define xPortPendSVHandler                      PendSV_Handler
+#define vPortSVCHandler                         SVC_Handler
+
+/* Ensure Cortex-M port compatibility. */
+#define SysTick_Handler                         xPortSysTickHandler
+
+#if (defined(__ARMCC_VERSION) || defined(__GNUC__) || defined(__ICCARM__))
+/* Include debug event definitions */
+#include "freertos_evr.h"
+#endif
+
+#endif /* FREERTOS_CONFIG_H */

--- a/Layer/App/Validation_FreeRTOS/main.c
+++ b/Layer/App/Validation_FreeRTOS/main.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cmsis_rv2.h"
+
+extern int stdio_init (void);
+
+int main (void) {
+  /* Initialize stdio */
+  stdio_init();
+
+  /* CMSIS-RTOS2 validation entry */
+  cmsis_rv2();
+}
+
+#if defined(__GNUC__) && !defined(__CC_ARM) && !defined(__ARMCC_VERSION)
+void _start (void) {
+  main();
+
+  for(;;);
+}
+#endif

--- a/Layer/App/Validation_FreeRTOS/retarget_stdio.c
+++ b/Layer/App/Validation_FreeRTOS/retarget_stdio.c
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------
+ * Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *      Name:    retarget_stdio.c
+ *      Purpose: Retarget stdio to USART
+ *
+ *---------------------------------------------------------------------------*/
+
+#include "Driver_USART.h"
+
+#define USART_DRV_NUM           0
+#define USART_BAUDRATE          115200
+
+#define _USART_Driver_(n)  Driver_USART##n
+#define  USART_Driver_(n) _USART_Driver_(n)
+ 
+extern ARM_DRIVER_USART  USART_Driver_(USART_DRV_NUM);
+#define ptrUSART       (&USART_Driver_(USART_DRV_NUM))
+
+/* Prototypes */
+int stdio_init     (void);
+int stderr_putchar (int ch);
+int stdout_putchar (int ch);
+int stdin_getchar  (void);
+
+/**
+  Initialize stdio
+ 
+  \return          0 on success, or -1 on error.
+*/
+int stdio_init (void) {
+  int32_t status;
+ 
+  status = ptrUSART->Initialize(NULL);
+  if (status != ARM_DRIVER_OK) return (-1);
+ 
+  status = ptrUSART->PowerControl(ARM_POWER_FULL);
+  if (status != ARM_DRIVER_OK) return (-1);
+ 
+  status = ptrUSART->Control(ARM_USART_MODE_ASYNCHRONOUS |
+                             ARM_USART_DATA_BITS_8       |
+                             ARM_USART_PARITY_NONE       |
+                             ARM_USART_STOP_BITS_1       |
+                             ARM_USART_FLOW_CONTROL_NONE,
+                             USART_BAUDRATE);
+  if (status != ARM_DRIVER_OK) return (-1);
+ 
+  status = ptrUSART->Control(ARM_USART_CONTROL_RX, 1);
+  if (status != ARM_DRIVER_OK) return (-1);
+ 
+  return (0);
+}
+
+/**
+  Put a character to the stderr
+ 
+  \param[in]   ch  Character to output
+  \return          The character written, or -1 on write error.
+*/
+int stderr_putchar (int ch) {
+  uint8_t buf[1];
+ 
+  buf[0] = (uint8_t)ch;
+  if (ptrUSART->Send(buf, 1) != ARM_DRIVER_OK) {
+    return (-1);
+  }
+  while (ptrUSART->GetTxCount() != 1);
+  return (ch);
+}
+
+/**
+  Put a character to the stdout
+
+  \param[in]   ch  Character to output
+  \return          The character written, or -1 on write error.
+*/
+int stdout_putchar (int ch) {
+  uint8_t buf[1];
+ 
+  buf[0] = (uint8_t)ch;
+  if (ptrUSART->Send(buf, 1) != ARM_DRIVER_OK) {
+    return (-1);
+  }
+  while (ptrUSART->GetTxCount() != 1);
+  return (ch);
+}
+
+/**
+  Get a character from the stdio
+ 
+  \return     The next character from the input, or -1 on read error.
+*/
+int stdin_getchar (void) {
+  uint8_t buf[1];
+ 
+  if (ptrUSART->Receive(buf, 1) != ARM_DRIVER_OK) {
+    return (-1);
+  }
+  while (ptrUSART->GetRxCount() != 1);
+  return (buf[0]);
+}

--- a/Layer/App/Validation_RTX5/App.clayer.yml
+++ b/Layer/App/Validation_RTX5/App.clayer.yml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: App
+  # name: CMSIS-RTOS2_Validation
+  description: Validation of CMSIS-RTOS2 RTX5 implementation
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: ARM::CMSIS-FreeRTOS
+
+  defines:
+    - PRINT_XML_REPORT=1
+  
+  add-paths:
+    - ../../Include
+    - ./RTE/CMSIS_RTOS2_Validation
+
+  misc:
+    - C*:
+      - -Wno-macro-redefined
+      - -Wno-pragma-pack
+      - -Wno-parentheses-equality
+
+  components:
+    # [Cvendor::]Cclass[&Cbundle]:Cgroup[:Csub][&Cvariant][@[>=]Cversion]
+    - component: ARM::CMSIS:RTOS2:Keil RTX5&Source
+
+  groups:
+    - group: Documentation
+      files:
+        - file: ../../README.md
+
+    - group: Source files
+      files:
+        - file: ./main.c 
+        - file: ./retarget_stdio.c
+
+    - group: CMSIS-RTOS2_Validation
+      files:
+        - file: ../../Source/cmsis_rv2.c
+        - file: ../../Source/RV2_Kernel.c
+        - file: ../../Source/RV2_Thread.c
+        - file: ../../Source/RV2_ThreadFlags.c
+        - file: ../../Source/RV2_GenWait.c
+        - file: ../../Source/RV2_Timer.c
+        - file: ../../Source/RV2_EventFlags.c
+        - file: ../../Source/RV2_Mutex.c
+        - file: ../../Source/RV2_Semaphore.c
+        - file: ../../Source/RV2_MemoryPool.c
+        - file: ../../Source/RV2_MessageQueue.c
+        - file: ../../Source/RV2_Common.c
+        - file: ./RTE/CMSIS_RTOS2_Validation/RV2_Config.c
+        - file: ./RTE/CMSIS_RTOS2_Validation/RV2_Config.h
+    
+    - group: Validation Framework
+      files:
+        - file: ../../Source/tf_main.c
+        - file: ../../Source/tf_report.c

--- a/Layer/App/Validation_RTX5/RTE/CMSIS/RTX_Config.c
+++ b/Layer/App/Validation_RTX5/RTE/CMSIS/RTX_Config.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * $Revision:   V5.1.1
+ *
+ * Project:     CMSIS-RTOS RTX
+ * Title:       RTX Configuration
+ *
+ * -----------------------------------------------------------------------------
+ */
+ 
+#include "cmsis_compiler.h"
+#include "rtx_os.h"
+ 
+// OS Idle Thread
+__WEAK __NO_RETURN void osRtxIdleThread (void *argument) {
+  (void)argument;
+
+  for (;;) {}
+}
+ 
+// OS Error Callback function
+__WEAK uint32_t osRtxErrorNotify (uint32_t code, void *object_id) {
+  (void)object_id;
+
+  switch (code) {
+    case osRtxErrorStackOverflow:
+      // Stack overflow detected for thread (thread_id=object_id)
+      break;
+    case osRtxErrorISRQueueOverflow:
+      // ISR Queue overflow detected when inserting object (object_id)
+      break;
+    case osRtxErrorTimerQueueOverflow:
+      // User Timer Callback Queue overflow detected for timer (timer_id=object_id)
+      break;
+    case osRtxErrorClibSpace:
+      // Standard C/C++ library libspace not available: increase OS_THREAD_LIBSPACE_NUM
+      break;
+    case osRtxErrorClibMutex:
+      // Standard C/C++ library mutex initialization failed
+      break;
+    default:
+      // Reserved
+      break;
+  }
+  for (;;) {}
+//return 0U;
+}

--- a/Layer/App/Validation_RTX5/RTE/CMSIS/RTX_Config.h
+++ b/Layer/App/Validation_RTX5/RTE/CMSIS/RTX_Config.h
@@ -1,0 +1,580 @@
+/*
+ * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * $Revision:   V5.5.2
+ *
+ * Project:     CMSIS-RTOS RTX
+ * Title:       RTX Configuration definitions
+ *
+ * -----------------------------------------------------------------------------
+ */
+ 
+#ifndef RTX_CONFIG_H_
+#define RTX_CONFIG_H_
+ 
+#ifdef   _RTE_
+#include "RTE_Components.h"
+#ifdef    RTE_RTX_CONFIG_H
+#include  RTE_RTX_CONFIG_H
+#endif
+#endif
+ 
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+ 
+// <h>System Configuration
+// =======================
+ 
+//   <o>Global Dynamic Memory size [bytes] <0-1073741824:8>
+//   <i> Defines the combined global dynamic memory size.
+//   <i> Default: 32768
+#ifndef OS_DYNAMIC_MEM_SIZE
+#define OS_DYNAMIC_MEM_SIZE         32768
+#endif
+ 
+//   <o>Kernel Tick Frequency [Hz] <1-1000000>
+//   <i> Defines base time unit for delays and timeouts.
+//   <i> Default: 1000 (1ms tick)
+#ifndef OS_TICK_FREQ
+#define OS_TICK_FREQ                1000
+#endif
+ 
+//   <e>Round-Robin Thread switching
+//   <i> Enables Round-Robin Thread switching.
+#ifndef OS_ROBIN_ENABLE
+#define OS_ROBIN_ENABLE             1
+#endif
+ 
+//     <o>Round-Robin Timeout <1-1000>
+//     <i> Defines how many ticks a thread will execute before a thread switch.
+//     <i> Default: 5
+#ifndef OS_ROBIN_TIMEOUT
+#define OS_ROBIN_TIMEOUT            5
+#endif
+ 
+//   </e>
+ 
+//   <o>ISR FIFO Queue
+//      <4=>  4 entries    <8=>   8 entries   <12=>  12 entries   <16=>  16 entries
+//     <24=> 24 entries   <32=>  32 entries   <48=>  48 entries   <64=>  64 entries
+//     <96=> 96 entries  <128=> 128 entries  <196=> 196 entries  <256=> 256 entries
+//   <i> RTOS Functions called from ISR store requests to this buffer.
+//   <i> Default: 16 entries
+#ifndef OS_ISR_FIFO_QUEUE
+#define OS_ISR_FIFO_QUEUE           32
+#endif
+ 
+//   <q>Object Memory usage counters
+//   <i> Enables object memory usage counters (requires RTX source variant).
+#ifndef OS_OBJ_MEM_USAGE
+#define OS_OBJ_MEM_USAGE            0
+#endif
+ 
+// </h>
+ 
+// <h>Thread Configuration
+// =======================
+ 
+//   <e>Object specific Memory allocation
+//   <i> Enables object specific memory allocation.
+#ifndef OS_THREAD_OBJ_MEM
+#define OS_THREAD_OBJ_MEM           0
+#endif
+ 
+//     <o>Number of user Threads <1-1000>
+//     <i> Defines maximum number of user threads that can be active at the same time.
+//     <i> Applies to user threads with system provided memory for control blocks.
+#ifndef OS_THREAD_NUM
+#define OS_THREAD_NUM               1
+#endif
+ 
+//     <o>Number of user Threads with default Stack size <0-1000>
+//     <i> Defines maximum number of user threads with default stack size.
+//     <i> Applies to user threads with zero stack size specified.
+#ifndef OS_THREAD_DEF_STACK_NUM
+#define OS_THREAD_DEF_STACK_NUM     0
+#endif
+ 
+//     <o>Total Stack size [bytes] for user Threads with user-provided Stack size <0-1073741824:8>
+//     <i> Defines the combined stack size for user threads with user-provided stack size.
+//     <i> Applies to user threads with user-provided stack size and system provided memory for stack.
+//     <i> Default: 0
+#ifndef OS_THREAD_USER_STACK_SIZE
+#define OS_THREAD_USER_STACK_SIZE   0
+#endif
+ 
+//   </e>
+ 
+//   <o>Default Thread Stack size [bytes] <96-1073741824:8>
+//   <i> Defines stack size for threads with zero stack size specified.
+//   <i> Default: 3072
+#ifndef OS_STACK_SIZE
+#define OS_STACK_SIZE               3072
+#endif
+ 
+//   <o>Idle Thread Stack size [bytes] <72-1073741824:8>
+//   <i> Defines stack size for Idle thread.
+//   <i> Default: 512
+#ifndef OS_IDLE_THREAD_STACK_SIZE
+#define OS_IDLE_THREAD_STACK_SIZE   512
+#endif
+ 
+//   <o>Idle Thread TrustZone Module Identifier
+//   <i> Defines TrustZone Thread Context Management Identifier.
+//   <i> Applies only to cores with TrustZone technology.
+//   <i> Default: 0 (not used)
+#ifndef OS_IDLE_THREAD_TZ_MOD_ID
+#define OS_IDLE_THREAD_TZ_MOD_ID    0
+#endif
+ 
+//   <q>Stack overrun checking
+//   <i> Enables stack overrun check at thread switch (requires RTX source variant).
+//   <i> Enabling this option increases slightly the execution time of a thread switch.
+#ifndef OS_STACK_CHECK
+#define OS_STACK_CHECK              1
+#endif
+ 
+//   <q>Stack usage watermark
+//   <i> Initializes thread stack with watermark pattern for analyzing stack usage.
+//   <i> Enabling this option increases significantly the execution time of thread creation.
+#ifndef OS_STACK_WATERMARK
+#define OS_STACK_WATERMARK          1
+#endif
+ 
+//   <o>Processor mode for Thread execution
+//     <0=> Unprivileged mode
+//     <1=> Privileged mode
+//   <i> Default: Privileged mode
+#ifndef OS_PRIVILEGE_MODE
+#define OS_PRIVILEGE_MODE           1
+#endif
+ 
+// </h>
+ 
+// <h>Timer Configuration
+// ======================
+ 
+//   <e>Object specific Memory allocation
+//   <i> Enables object specific memory allocation.
+#ifndef OS_TIMER_OBJ_MEM
+#define OS_TIMER_OBJ_MEM            0
+#endif
+ 
+//     <o>Number of Timer objects <1-1000>
+//     <i> Defines maximum number of objects that can be active at the same time.
+//     <i> Applies to objects with system provided memory for control blocks.
+#ifndef OS_TIMER_NUM
+#define OS_TIMER_NUM                1
+#endif
+ 
+//   </e>
+ 
+//   <o>Timer Thread Priority
+//      <8=> Low
+//     <16=> Below Normal  <24=> Normal  <32=> Above Normal
+//     <40=> High
+//     <48=> Realtime
+//   <i> Defines priority for timer thread
+//   <i> Default: High
+#ifndef OS_TIMER_THREAD_PRIO
+#define OS_TIMER_THREAD_PRIO        40
+#endif
+ 
+//   <o>Timer Thread Stack size [bytes] <0-1073741824:8>
+//   <i> Defines stack size for Timer thread.
+//   <i> May be set to 0 when timers are not used.
+//   <i> Default: 512
+#ifndef OS_TIMER_THREAD_STACK_SIZE
+#define OS_TIMER_THREAD_STACK_SIZE  512
+#endif
+ 
+//   <o>Timer Thread TrustZone Module Identifier
+//   <i> Defines TrustZone Thread Context Management Identifier.
+//   <i> Applies only to cores with TrustZone technology.
+//   <i> Default: 0 (not used)
+#ifndef OS_TIMER_THREAD_TZ_MOD_ID
+#define OS_TIMER_THREAD_TZ_MOD_ID   0
+#endif
+ 
+//   <o>Timer Callback Queue entries <0-256>
+//   <i> Number of concurrent active timer callback functions.
+//   <i> May be set to 0 when timers are not used.
+//   <i> Default: 4
+#ifndef OS_TIMER_CB_QUEUE
+#define OS_TIMER_CB_QUEUE           4
+#endif
+ 
+// </h>
+ 
+// <h>Event Flags Configuration
+// ============================
+ 
+//   <e>Object specific Memory allocation
+//   <i> Enables object specific memory allocation.
+#ifndef OS_EVFLAGS_OBJ_MEM
+#define OS_EVFLAGS_OBJ_MEM          0
+#endif
+ 
+//     <o>Number of Event Flags objects <1-1000>
+//     <i> Defines maximum number of objects that can be active at the same time.
+//     <i> Applies to objects with system provided memory for control blocks.
+#ifndef OS_EVFLAGS_NUM
+#define OS_EVFLAGS_NUM              1
+#endif
+ 
+//   </e>
+ 
+// </h>
+ 
+// <h>Mutex Configuration
+// ======================
+ 
+//   <e>Object specific Memory allocation
+//   <i> Enables object specific memory allocation.
+#ifndef OS_MUTEX_OBJ_MEM
+#define OS_MUTEX_OBJ_MEM            0
+#endif
+ 
+//     <o>Number of Mutex objects <1-1000>
+//     <i> Defines maximum number of objects that can be active at the same time.
+//     <i> Applies to objects with system provided memory for control blocks.
+#ifndef OS_MUTEX_NUM
+#define OS_MUTEX_NUM                1
+#endif
+ 
+//   </e>
+ 
+// </h>
+ 
+// <h>Semaphore Configuration
+// ==========================
+ 
+//   <e>Object specific Memory allocation
+//   <i> Enables object specific memory allocation.
+#ifndef OS_SEMAPHORE_OBJ_MEM
+#define OS_SEMAPHORE_OBJ_MEM        0
+#endif
+ 
+//     <o>Number of Semaphore objects <1-1000>
+//     <i> Defines maximum number of objects that can be active at the same time.
+//     <i> Applies to objects with system provided memory for control blocks.
+#ifndef OS_SEMAPHORE_NUM
+#define OS_SEMAPHORE_NUM            1
+#endif
+ 
+//   </e>
+ 
+// </h>
+ 
+// <h>Memory Pool Configuration
+// ============================
+ 
+//   <e>Object specific Memory allocation
+//   <i> Enables object specific memory allocation.
+#ifndef OS_MEMPOOL_OBJ_MEM
+#define OS_MEMPOOL_OBJ_MEM          0
+#endif
+ 
+//     <o>Number of Memory Pool objects <1-1000>
+//     <i> Defines maximum number of objects that can be active at the same time.
+//     <i> Applies to objects with system provided memory for control blocks.
+#ifndef OS_MEMPOOL_NUM
+#define OS_MEMPOOL_NUM              1
+#endif
+ 
+//     <o>Data Storage Memory size [bytes] <0-1073741824:8>
+//     <i> Defines the combined data storage memory size.
+//     <i> Applies to objects with system provided memory for data storage.
+//     <i> Default: 0
+#ifndef OS_MEMPOOL_DATA_SIZE
+#define OS_MEMPOOL_DATA_SIZE        0
+#endif
+ 
+//   </e>
+ 
+// </h>
+ 
+// <h>Message Queue Configuration
+// ==============================
+ 
+//   <e>Object specific Memory allocation
+//   <i> Enables object specific memory allocation.
+#ifndef OS_MSGQUEUE_OBJ_MEM
+#define OS_MSGQUEUE_OBJ_MEM         0
+#endif
+ 
+//     <o>Number of Message Queue objects <1-1000>
+//     <i> Defines maximum number of objects that can be active at the same time.
+//     <i> Applies to objects with system provided memory for control blocks.
+#ifndef OS_MSGQUEUE_NUM
+#define OS_MSGQUEUE_NUM             1
+#endif
+ 
+//     <o>Data Storage Memory size [bytes] <0-1073741824:8>
+//     <i> Defines the combined data storage memory size.
+//     <i> Applies to objects with system provided memory for data storage.
+//     <i> Default: 0
+#ifndef OS_MSGQUEUE_DATA_SIZE
+#define OS_MSGQUEUE_DATA_SIZE       0
+#endif
+ 
+//   </e>
+ 
+// </h>
+ 
+// <h>Event Recorder Configuration
+// ===============================
+ 
+//   <e>Global Initialization
+//   <i> Initialize Event Recorder during 'osKernelInitialize'.
+#ifndef OS_EVR_INIT
+#define OS_EVR_INIT                 0
+#endif
+ 
+//     <q>Start recording
+//     <i> Start event recording after initialization.
+#ifndef OS_EVR_START
+#define OS_EVR_START                1
+#endif
+ 
+//     <h>Global Event Filter Setup
+//     <i> Initial recording level applied to all components.
+//       <o.0>Error events
+//       <o.1>API function call events
+//       <o.2>Operation events
+//       <o.3>Detailed operation events
+//     </h>
+#ifndef OS_EVR_LEVEL
+#define OS_EVR_LEVEL                0x00U
+#endif
+ 
+//     <h>RTOS Event Filter Setup
+//     <i> Recording levels for RTX components.
+//     <i> Only applicable if events for the respective component are generated.
+ 
+//       <e.7>Memory Management
+//       <i> Recording level for Memory Management events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_MEMORY_LEVEL
+#define OS_EVR_MEMORY_LEVEL         0x81U
+#endif
+ 
+//       <e.7>Kernel
+//       <i> Recording level for Kernel events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_KERNEL_LEVEL
+#define OS_EVR_KERNEL_LEVEL         0x81U
+#endif
+ 
+//       <e.7>Thread
+//       <i> Recording level for Thread events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_THREAD_LEVEL
+#define OS_EVR_THREAD_LEVEL         0x85U
+#endif
+ 
+//       <e.7>Generic Wait
+//       <i> Recording level for Generic Wait events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_WAIT_LEVEL
+#define OS_EVR_WAIT_LEVEL           0x81U
+#endif
+ 
+//       <e.7>Thread Flags
+//       <i> Recording level for Thread Flags events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_THFLAGS_LEVEL
+#define OS_EVR_THFLAGS_LEVEL        0x81U
+#endif
+ 
+//       <e.7>Event Flags
+//       <i> Recording level for Event Flags events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_EVFLAGS_LEVEL
+#define OS_EVR_EVFLAGS_LEVEL        0x81U
+#endif
+ 
+//       <e.7>Timer
+//       <i> Recording level for Timer events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_TIMER_LEVEL
+#define OS_EVR_TIMER_LEVEL          0x81U
+#endif
+ 
+//       <e.7>Mutex
+//       <i> Recording level for Mutex events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_MUTEX_LEVEL
+#define OS_EVR_MUTEX_LEVEL          0x81U
+#endif
+ 
+//       <e.7>Semaphore
+//       <i> Recording level for Semaphore events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_SEMAPHORE_LEVEL
+#define OS_EVR_SEMAPHORE_LEVEL      0x81U
+#endif
+ 
+//       <e.7>Memory Pool
+//       <i> Recording level for Memory Pool events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_MEMPOOL_LEVEL
+#define OS_EVR_MEMPOOL_LEVEL        0x81U
+#endif
+ 
+//       <e.7>Message Queue
+//       <i> Recording level for Message Queue events.
+//         <o.0>Error events
+//         <o.1>API function call events
+//         <o.2>Operation events
+//         <o.3>Detailed operation events
+//       </e>
+#ifndef OS_EVR_MSGQUEUE_LEVEL
+#define OS_EVR_MSGQUEUE_LEVEL       0x81U
+#endif
+ 
+//     </h>
+ 
+//   </e>
+ 
+//   <h>RTOS Event Generation
+//   <i> Enables event generation for RTX components (requires RTX source variant).
+ 
+//     <q>Memory Management
+//     <i> Enables Memory Management event generation.
+#ifndef OS_EVR_MEMORY
+#define OS_EVR_MEMORY               0
+#endif
+ 
+//     <q>Kernel
+//     <i> Enables Kernel event generation.
+#ifndef OS_EVR_KERNEL
+#define OS_EVR_KERNEL               0
+#endif
+ 
+//     <q>Thread
+//     <i> Enables Thread event generation.
+#ifndef OS_EVR_THREAD
+#define OS_EVR_THREAD               0
+#endif
+ 
+//     <q>Generic Wait
+//     <i> Enables Generic Wait event generation.
+#ifndef OS_EVR_WAIT
+#define OS_EVR_WAIT                 0
+#endif
+ 
+//     <q>Thread Flags
+//     <i> Enables Thread Flags event generation.
+#ifndef OS_EVR_THFLAGS
+#define OS_EVR_THFLAGS              0
+#endif
+ 
+//     <q>Event Flags
+//     <i> Enables Event Flags event generation.
+#ifndef OS_EVR_EVFLAGS
+#define OS_EVR_EVFLAGS              0
+#endif
+ 
+//     <q>Timer
+//     <i> Enables Timer event generation.
+#ifndef OS_EVR_TIMER
+#define OS_EVR_TIMER                0
+#endif
+ 
+//     <q>Mutex
+//     <i> Enables Mutex event generation.
+#ifndef OS_EVR_MUTEX
+#define OS_EVR_MUTEX                0
+#endif
+ 
+//     <q>Semaphore
+//     <i> Enables Semaphore event generation.
+#ifndef OS_EVR_SEMAPHORE
+#define OS_EVR_SEMAPHORE            0
+#endif
+ 
+//     <q>Memory Pool
+//     <i> Enables Memory Pool event generation.
+#ifndef OS_EVR_MEMPOOL
+#define OS_EVR_MEMPOOL              0
+#endif
+ 
+//     <q>Message Queue
+//     <i> Enables Message Queue event generation.
+#ifndef OS_EVR_MSGQUEUE
+#define OS_EVR_MSGQUEUE             0
+#endif
+ 
+//   </h>
+ 
+// </h>
+ 
+// Number of Threads which use standard C/C++ library libspace
+// (when thread specific memory allocation is not used).
+#if (OS_THREAD_OBJ_MEM == 0)
+#ifndef OS_THREAD_LIBSPACE_NUM
+#define OS_THREAD_LIBSPACE_NUM      4
+#endif
+#else
+#define OS_THREAD_LIBSPACE_NUM      OS_THREAD_NUM
+#endif
+ 
+//------------- <<< end of configuration section >>> ---------------------------
+ 
+#endif  // RTX_CONFIG_H_

--- a/Layer/App/Validation_RTX5/RTE/CMSIS_RTOS2_Validation/RV2_Config.c
+++ b/Layer/App/Validation_RTX5/RTE/CMSIS_RTOS2_Validation/RV2_Config.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cmsis_rv2.h"
+#include "RV2_Config_Device.h"
+
+#if defined(__CORTEX_A)
+#include "irq_ctrl.h"
+#endif
+
+/* Prototypes */
+void TST_IRQ_HANDLER_A (void);
+void TST_IRQ_HANDLER_B (void);
+void (*TST_IRQHandler_A)(void);
+void (*TST_IRQHandler_B)(void);
+
+extern int stdout_putchar (int ch);
+
+/*
+  Primary interrupt handler
+*/
+void TST_IRQ_HANDLER_A (void) {
+
+  if (TST_IRQHandler_A != NULL) {
+    TST_IRQHandler_A();
+  }
+}
+
+/*
+  Secondary interrupt handler
+*/
+void TST_IRQ_HANDLER_B (void) {
+
+  if (TST_IRQHandler_B != NULL) {
+    TST_IRQHandler_B();
+  }
+}
+
+/*
+  Test suite initialization
+*/
+void TS_Init (void) {
+
+#if defined(__CORTEX_M)
+  /* Set primary and secondary interrupt priority */
+  NVIC_SetPriority ((IRQn_Type)TST_IRQ_NUM_A, 5U);
+  NVIC_SetPriority ((IRQn_Type)TST_IRQ_NUM_B, 4U);
+
+  /* Enable interrupts */
+  NVIC_EnableIRQ((IRQn_Type)TST_IRQ_NUM_A);
+  NVIC_EnableIRQ((IRQn_Type)TST_IRQ_NUM_B);
+
+#elif defined(__CORTEX_A)
+  /* Disable interrupts and clear potential pending bits */
+  IRQ_Disable ((IRQn_ID_t)TST_IRQ_NUM_A);
+  IRQ_Disable ((IRQn_ID_t)TST_IRQ_NUM_B);
+
+  IRQ_ClearPending ((IRQn_ID_t)TST_IRQ_NUM_A);
+  IRQ_ClearPending ((IRQn_ID_t)TST_IRQ_NUM_B);
+
+  /* Set edge-triggered IRQ */
+  IRQ_SetMode ((IRQn_ID_t)TST_IRQ_NUM_A, IRQ_MODE_TRIG_EDGE);
+  IRQ_SetMode ((IRQn_ID_t)TST_IRQ_NUM_B, IRQ_MODE_TRIG_EDGE);
+
+  /* Register interrupt handlers */
+  IRQ_SetHandler((IRQn_ID_t)TST_IRQ_NUM_A, TST_IRQ_HANDLER_A);
+  IRQ_SetHandler((IRQn_ID_t)TST_IRQ_NUM_B, TST_IRQ_HANDLER_B);
+
+  /* Enable interrupts */
+  IRQ_Enable((IRQn_ID_t)TST_IRQ_NUM_A);
+  IRQ_Enable((IRQn_ID_t)TST_IRQ_NUM_B);
+#endif
+}
+
+/*
+  Test suite de-initialization
+*/
+void TS_Uninit (void) {
+  /* Close debug session here */
+
+  /* Note:
+     VHT model shall have parameter shutdown_on_eot set to true.
+     Simulation is then shutdown when EOT, ASCII4, character is
+     transmitted via UART.
+   */
+  stdout_putchar (0x04);
+}
+
+/*
+  Enable interrupt trigger in the IRQ controller.
+*/
+void EnableIRQ (int32_t irq_num) {
+
+  if (irq_num == IRQ_A) {
+    irq_num = TST_IRQ_NUM_A;
+  } else {
+    irq_num = TST_IRQ_NUM_B;
+  }
+
+#if defined(__CORTEX_M)
+  NVIC_EnableIRQ((IRQn_Type)irq_num);
+#elif defined(__CORTEX_A)
+  IRQ_Enable((IRQn_ID_t)irq_num);
+#endif
+}
+
+/*
+  Disable interrupt trigger in the IRQ controller.
+*/
+void DisableIRQ (int32_t irq_num) {
+
+  if (irq_num == IRQ_A) {
+    irq_num = TST_IRQ_NUM_A;
+  } else {
+    irq_num = TST_IRQ_NUM_B;
+  }
+
+#if defined(__CORTEX_M)
+  NVIC_DisableIRQ((IRQn_Type)irq_num);
+#elif defined(__CORTEX_A)
+  IRQ_Disable((IRQn_ID_t)irq_num);
+#endif
+}
+
+/*
+  Set pending interrupt in the IRQ controller.
+*/
+void SetPendingIRQ (int32_t irq_num) {
+
+  if (irq_num == IRQ_A) {
+    irq_num = TST_IRQ_NUM_A;
+  } else {
+    irq_num = TST_IRQ_NUM_B;
+  }
+
+#if defined(__CORTEX_M)
+  NVIC_SetPendingIRQ((IRQn_Type)irq_num);
+
+  __DSB();
+  __ISB();
+  __DMB();
+
+  while (NVIC_GetPendingIRQ((IRQn_Type)irq_num) != 0);
+
+#elif defined(__CORTEX_A)
+  __disable_irq();
+  IRQ_SetPending((IRQn_ID_t)irq_num);
+  __enable_irq();
+
+  __DSB();
+  __ISB();
+  __DMB();
+
+  while (IRQ_GetPending((IRQn_ID_t)irq_num) != 0);
+#endif
+}

--- a/Layer/App/Validation_RTX5/RTE/CMSIS_RTOS2_Validation/RV2_Config.h
+++ b/Layer/App/Validation_RTX5/RTE/CMSIS_RTOS2_Validation/RV2_Config.h
@@ -1,0 +1,414 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_H__
+#define RV2_CONFIG_H__
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <h> CMSIS-RTOS2 Test Suite Configuration
+//   <o>Test Runner Thread Stack size <128-16384>
+//   <i> Defines stack size for test runner thread.
+//   <i> Default: 1024
+#define MAIN_THREAD_STACK                 1024
+
+// <o> Tick Timer Interval [us] <1-1000000>
+// <i> Defines kernel tick timer interval value.
+// <i> Default: 1000
+#define RTOS2_TICK_FREQ                   1000
+
+// <h> Object Implementation Specific Configuration
+// <o> Maximum Thread Flags
+// <i> Maximum number of Thread Flags available per Thread object
+#define MAX_THREADFLAGS_CNT               31
+// <o> Maximum Event Flags
+// <i> Maximum number of Event Flags available per Event Flags object
+#define MAX_EVENTFLAGS_CNT                31
+// <o> Maximum Mutex Locks
+// <i> Maximum number of recursive Mutex locks per Mutex object
+#define MAX_MUTEX_LOCK_CNT                255
+// <o> Maximum Semaphore Tokens
+// <i> Maximum number of available tokens per Semaphore object
+#define MAX_SEMAPHORE_TOKEN_CNT           255
+// </h>
+
+// <h> Disable Test Cases
+// <i> Uncheck to disable an individual test case
+//   <e0>Kernel Information and Control
+//     <q01>TC_osKernelInitialize_1
+//     <q02>TC_osKernelGetInfo_1
+//     <q03>TC_osKernelGetState_1
+//     <q04>TC_osKernelGetState_2
+//     <q05>TC_osKernelStart_1
+//     <q06>TC_osKernelLock_1
+//     <q07>TC_osKernelLock_2
+//     <q08>TC_osKernelUnlock_1
+//     <q09>TC_osKernelUnlock_2
+//     <q10>TC_osKernelRestoreLock_1
+//     <q11>TC_osKernelSuspend_1
+//     <q12>TC_osKernelResume_1
+//     <q13>TC_osKernelGetTickCount_1
+//     <q14>TC_osKernelGetTickFreq_1
+//     <q15>TC_osKernelGetSysTimerCount_1
+//     <q16>TC_osKernelGetSysTimerFreq_1
+#define TC_OSKERNEL_EN                    1
+#define TC_OSKERNELINITIALIZE_1_EN        1
+#define TC_OSKERNELGETINFO_1_EN           1
+#define TC_OSKERNELGETSTATE_1_EN          1
+#define TC_OSKERNELGETSTATE_2_EN          1
+#define TC_OSKERNELSTART_1_EN             1
+#define TC_OSKERNELLOCK_1_EN              1
+#define TC_OSKERNELLOCK_2_EN              1
+#define TC_OSKERNELUNLOCK_1_EN            1
+#define TC_OSKERNELUNLOCK_2_EN            1
+#define TC_OSKERNELRESTORELOCK_1_EN       1
+#define TC_OSKERNELSUSPEND_1_EN           1
+#define TC_OSKERNELRESUME_1_EN            1
+#define TC_OSKERNELGETTICKCOUNT_EN        1
+#define TC_OSKERNELGETTICKFREQ_EN         1
+#define TC_OSKERNELGETSYSTIMERCOUNT_EN    1
+#define TC_OSKERNELGETSYSTIMERFREQ_EN     1
+//   </e>
+
+//   <e0>Thread Management
+//     <q01>TC_osThreadNew_1
+//     <q02>TC_osThreadNew_2
+//     <q03>TC_osThreadNew_3
+//     <q04>TC_osThreadNew_4
+//     <q05>TC_osThreadNew_5
+//     <q06>TC_osThreadNew_6
+//     <q07>TC_osThreadNew_7
+//     <q08>TC_osThreadGetName_1
+//     <q09>TC_osThreadGetId_1
+//     <q10>TC_osThreadGetState_1
+//     <q11>TC_osThreadGetState_2
+//     <q12>TC_osThreadGetState_3
+//     <q13>TC_osThreadSetPriority_1
+//     <q14>TC_osThreadSetPriority_2
+//     <q15>TC_osThreadGetPriority_1
+//     <q16>TC_osThreadYield_1
+//     <q17>TC_osThreadSuspend_1
+//     <q18>TC_osThreadResume_1
+//     <q19>TC_osThreadDetach_1
+//     <q20>TC_osThreadDetach_2
+//     <q21>TC_osThreadJoin_1
+//     <q22>TC_osThreadJoin_2
+//     <q23>TC_osThreadJoin_3
+//     <q24>TC_osThreadExit_1
+//     <q25>TC_osThreadTerminate_1
+//     <q26>TC_osThreadGetStackSize_1
+//     <q27>TC_osThreadGetStackSpace_1
+//     <q28>TC_osThreadGetCount_1
+//     <q29>TC_osThreadEnumerate_1
+//     <q30>TC_ThreadNew
+//     <q31>TC_ThreadMultiInstance
+//     <q32>TC_ThreadTerminate
+//     <q33>TC_ThreadRestart
+//     <q34>TC_ThreadPriorityExec
+//     <q35>TC_ThreadYield
+//     <q36>TC_ThreadSuspendResume
+//     <q37>TC_ThreadReturn
+//     <q38>TC_ThreadAllocation
+#define TC_OSTHREAD_EN                    1
+#define TC_OSTHREADNEW_1_EN               1
+#define TC_OSTHREADNEW_2_EN               1
+#define TC_OSTHREADNEW_3_EN               1
+#define TC_OSTHREADNEW_4_EN               1
+#define TC_OSTHREADNEW_5_EN               1
+#define TC_OSTHREADNEW_6_EN               1
+#define TC_OSTHREADNEW_7_EN               1
+#define TC_OSTHREADGETNAME_1_EN           1
+#define TC_OSTHREADGETID_1_EN             1
+#define TC_OSTHREADGGETSTATE_1_EN         1
+#define TC_OSTHREADGGETSTATE_2_EN         1
+#define TC_OSTHREADGGETSTATE_3_EN         1
+#define TC_OSTHREADSETPRIORITY_1_EN       1
+#define TC_OSTHREADSETPRIORITY_2_EN       1
+#define TC_OSTHREADGETPRIORITY_1_EN       1
+#define TC_OSTHREADYIELD_1_EN             1
+#define TC_OSTHREADSUSPEND_1_EN           1
+#define TC_OSTHREADRESUME_1_EN            1
+#define TC_OSTHREADDETACH_1_EN            1
+#define TC_OSTHREADDETACH_2_EN            1
+#define TC_OSTHREADJOIN_1_EN              1
+#define TC_OSTHREADJOIN_2_EN              1
+#define TC_OSTHREADJOIN_3_EN              1
+#define TC_OSTHREADEXIT_1_EN              1
+#define TC_OSTHREADTERMINATE_1_EN         1
+#define TC_OSTHREADGETSTACKSIZE_1_EN      1
+#define TC_OSTHREADGETSTACKSPACE_1_EN     1
+#define TC_OSTHREADGETCOUNT_1_EN          1
+#define TC_OSTHREADENUMERATE_1_EN         1
+#define TC_THREADNEW_EN                   1
+#define TC_THREADMULTIINSTANCE_EN         1
+#define TC_THREADTERMINATE_EN             1
+#define TC_THREADRESTART_EN               1
+#define TC_THREADPRIORITYEXEC_EN          1
+#define TC_THREADYIELD_EN                 1
+#define TC_THREADSUSPENDRESUME_EN         1
+#define TC_THREADRETURN_EN                1
+#define TC_THREADALLOCATION_EN            1
+//   </e>
+
+//   <e0>Thread Flags
+//     <q01>TC_ThreadFlagsMainThread,
+//     <q02>TC_ThreadFlagsChildThread,
+//     <q03>TC_ThreadFlagsChildToParent
+//     <q04>TC_ThreadFlagsChildToChild
+//     <q05>TC_ThreadFlagsWaitTimeout
+//     <q06>TC_ThreadFlagsCheckTimeout
+//     <q07>TC_ThreadFlagsParam
+//     <q08>TC_ThreadFlagsInterrupts
+#define TC_OSTHREADFLAGS_EN               1
+#define TC_THREADFLAGSMAINTHREAD_EN       1
+#define TC_THREADFLAGSCHILDTHREAD_EN      1
+#define TC_THREADFLAGSCHILDTOPARENT_EN    1
+#define TC_THREADFLAGSCHILDTOCHILD_EN     1
+#define TC_THREADFLAGSWAITTIMEOUT_EN      1
+#define TC_THREADFLAGSCHECKTIMEOUT_EN     1
+#define TC_THREADFLAGSPARAM_EN            1
+#define TC_THREADFLAGSINTERRUPTS_EN       1
+//   </e>
+
+//   <e0>Generic Wait Functions
+//     <q01>TC_GenWaitBasic
+//     <q02>TC_GenWaitInterrupts
+#define TC_OSDELAY_EN                     1
+#define TC_GENWAITBASIC_EN                1
+#define TC_GENWAITINTERRUPTS_EN           1
+//   </e>
+
+//   <e0>Timer Management
+//     <q01>TC_osTimerNew_1
+//     <q02>TC_osTimerNew_2
+//     <q03>TC_osTimerNew_3
+//     <q04>TC_osTimerGetName_1
+//     <q05>TC_osTimerStart_1
+//     <q06>TC_osTimerStop_1
+//     <q07>TC_osTimerStop_2
+//     <q08>TC_osTimerIsRunning_1
+//     <q09>TC_osTimerDelete_1
+//     <q10>TC_TimerAllocation
+//     <q11>TC_TimerOneShot
+//     <q12>TC_TimerPeriodic
+#define TC_OSTIMER_EN                     1
+#define TC_OSTIMERNEW_1_EN                1
+#define TC_OSTIMERNEW_2_EN                1
+#define TC_OSTIMERNEW_3_EN                1
+#define TC_OSTIMERGETNAME_1_EN            1
+#define TC_OSTIMERSTART_1_EN              1
+#define TC_OSTIMERSTOP_1_EN               1
+#define TC_OSTIMERSTOP_2_EN               1
+#define TC_OSTIMERISRUNNING_1_EN          1
+#define TC_OSTIMERDELETE_1_EN             1
+#define TC_TIMERONESHOT_EN                1
+#define TC_TIMERPERIODIC_EN               1
+#define TC_TIMERALLOCATION_EN             1
+//   </e>
+
+//   <e0>Event Flags
+//     <q01>TC_osEventFlagsNew_1
+//     <q02>TC_osEventFlagsNew_2
+//     <q03>TC_osEventFlagsNew_3
+//     <q04>TC_osEventFlagsSet_1
+//     <q05>TC_osEventFlagsClear_1
+//     <q06>TC_osEventFlagsGet_1
+//     <q07>TC_osEventFlagsWait_1
+//     <q08>TC_osEventFlagsDelete_1
+//     <q09>TC_osEventFlagsGetName_1
+//     <q00>TC_EventFlagsAllocation,
+//     <q11>TC_EventFlagsInterThreads,
+//     <q12>TC_EventFlagsCheckTimeout,
+//     <q13>TC_EventFlagsWaitTimeout,
+//     <q14>TC_EventFlagsDeleteWaiting
+#define TC_OSEVENTFLAGS_EN                1
+#define TC_OSEVENTFLAGSNEW_1_EN           1
+#define TC_OSEVENTFLAGSNEW_2_EN           1
+#define TC_OSEVENTFLAGSNEW_3_EN           1
+#define TC_OSEVENTFLAGSSET_1_EN           1
+#define TC_OSEVENTFLAGSCLEAR_1_EN         1
+#define TC_OSEVENTFLAGSGET_1_EN           1
+#define TC_OSEVENTFLAGSWAIT_1_EN          1
+#define TC_OSEVENTFLAGSDELETE_1_EN        1
+#define TC_OSEVENTFLAGSGETNAME_1_EN       1
+#define TC_EVENTFLAGSALLOCATION_EN        1
+#define TC_EVENTFLAGSINTERTHREADS_EN      1
+#define TC_EVENTFLAGSCHECKTIMEOUT_EN      1
+#define TC_EVENTFLAGSWAITTIMEOUT_EN       1
+#define TC_EVENTFLAGSDELETEWAITING_EN     1
+//   </e>
+
+//   <e0>Mutex Management
+//     <q01>TC_osMutexNew_1
+//     <q02>TC_osMutexNew_2
+//     <q03>TC_osMutexNew_3
+//     <q04>TC_osMutexNew_4
+//     <q05>TC_osMutexNew_5
+//     <q06>TC_osMutexNew_6
+//     <q07>TC_osMutexGetName_1
+//     <q08>TC_osMutexAcquire_1
+//     <q09>TC_osMutexAcquire_2
+//     <q10>TC_osMutexRelease_1
+//     <q11>TC_osMutexGetOwner_1
+//     <q12>TC_osMutexDelete_1
+//     <q13>TC_MutexAllocation
+//     <q14>TC_MutexCheckTimeout
+//     <q15>TC_MutexRobust
+//     <q16>TC_MutexPrioInherit
+//     <q17>TC_MutexNestedAcquire
+//     <q18>TC_MutexPriorityInversion
+//     <q19>TC_MutexOwnership
+#define TC_OSMUTEX_EN                     1
+#define TC_OSMUTEXNEW_1_EN                1
+#define TC_OSMUTEXNEW_2_EN                1
+#define TC_OSMUTEXNEW_3_EN                1
+#define TC_OSMUTEXNEW_4_EN                1
+#define TC_OSMUTEXNEW_5_EN                1
+#define TC_OSMUTEXNEW_6_EN                1
+#define TC_OSMUTEXGETNAME_1_EN            1
+#define TC_OSMUTEXACQUIRE_1_EN            1
+#define TC_OSMUTEXACQUIRE_2_EN            1
+#define TC_OSMUTEXRELEASE_1_EN            1
+#define TC_OSMUTEXGETOWNER_1_EN           1
+#define TC_OSMUTEXDELETE_1_EN             1
+#define TC_MUTEXALLOCATION_EN             1
+#define TC_MUTEXCHECKTIMEOUT_EN           1
+#define TC_MUTEXROBUST_EN                 1
+#define TC_MUTEXPRIOINHERIT_EN            1
+#define TC_MUTEXNESTEDACQUIRE_EN          1
+#define TC_MUTEXPRIORITYINVERSION_EN      1
+#define TC_MUTEXOWNERSHIP_EN              1
+//   </e>
+
+//   <e0>Semaphores
+//     <q01>TC_osSemaphoreNew_1
+//     <q02>TC_osSemaphoreNew_2
+//     <q03>TC_osSemaphoreNew_3
+//     <q04>TC_osSemaphoreGetName_1
+//     <q05>TC_osSemaphoreAcquire_1
+//     <q06>TC_osSemaphoreRelease_1
+//     <q07>TC_osSemaphoreGetCount_1
+//     <q08>TC_osSemaphoreDelete_1
+//     <q09>TC_SemaphoreAllocation
+//     <q00>TC_SemaphoreCreateAndDelete
+//     <q11>TC_SemaphoreObtainCounting
+//     <q12>TC_SemaphoreObtainBinary
+//     <q13>TC_SemaphoreWaitForBinary
+//     <q14>TC_SemaphoreWaitForCounting
+//     <q15>TC_SemaphoreZeroCount
+//     <q16>TC_SemaphoreWaitTimeout
+//     <q17>TC_SemaphoreCheckTimeout
+#define TC_OSSEMAPHORE_EN                 1
+#define TC_OSSEMAPHORENEW_1_EN            1
+#define TC_OSSEMAPHORENEW_2_EN            1
+#define TC_OSSEMAPHORENEW_3_EN            1
+#define TC_OSSEMAPHOREGETNAME_1_EN        1
+#define TC_OSSEMAPHOREACQUIRE_1_EN        1
+#define TC_OSSEMAPHORERELEASE_1_EN        1
+#define TC_OSSEMAPHOREGETCOUNT_1_EN       1
+#define TC_OSSEMAPHOREDELETE_1_EN         1
+#define TC_SEMAPHOREALLOCATION_EN         1
+#define TC_SEMAPHORECREATEANDDELETE_EN    1
+#define TC_SEMAPHOREOBTAINCOUNTING_EN     1
+#define TC_SEMAPHOREOBTAINBINARY_EN       1
+#define TC_SEMAPHOREWAITFORBINARY_EN      1
+#define TC_SEMAPHOREWAITFORCOUNTING_EN    1
+#define TC_SEMAPHOREZEROCOUNT_EN          1
+#define TC_SEMAPHOREWAITTIMEOUT_EN        1
+#define TC_SEMAPHORECHECKTIMEOUT_EN       1
+//   </e>
+
+//   <e0>Memory Pool
+//     <q01>TC_osMemoryPoolNew_1
+//     <q02>TC_osMemoryPoolNew_2
+//     <q03>TC_osMemoryPoolNew_3
+//     <q04>TC_osMemoryPoolGetName_1
+//     <q05>TC_osMemoryPoolAlloc_1
+//     <q06>TC_osMemoryPoolFree_1
+//     <q07>TC_osMemoryPoolGetCapacity_1
+//     <q08>TC_osMemoryPoolGetBlockSize_1
+//     <q09>TC_osMemoryPoolGetCount_1
+//     <q00>TC_osMemoryPoolGetSpace_1
+//     <q11>TC_osMemoryPoolDelete_1
+//     <q12>TC_MemPoolAllocation
+//     <q13>TC_MemPoolAllocAndFree
+//     <q14>TC_MemPoolAllocAndFreeComb
+//     <q15>TC_MemPoolZeroInit
+#define TC_OSMEMORYPOOL_EN                1
+#define TC_OSMEMORYPOOLNEW_1_EN           1
+#define TC_OSMEMORYPOOLNEW_2_EN           1
+#define TC_OSMEMORYPOOLNEW_3_EN           1
+#define TC_OSMEMORYPOOLGETNAME_1_EN       1
+#define TC_OSMEMORYPOOLALLOC_1_EN         1
+#define TC_OSMEMORYPOOLFREE_1_EN          1
+#define TC_OSMEMORYPOOLGETCAPACITY_1_EN   1
+#define TC_OSMEMORYPOOLGETBLOCKSIZE_1_EN  1
+#define TC_OSMEMORYPOOLGETCOUNT_1_EN      1
+#define TC_OSMEMORYPOOLGETSPACE_1_EN      1
+#define TC_OSMEMORYPOOLDELETE_1_EN        1
+#define TC_MEMPOOLALLOCATION_EN           1
+#define TC_MEMPOOLALLOCANDFREE_EN         1
+#define TC_MEMPOOLALLOCANDFREECOMB_EN     1
+#define TC_MEMPOOLZEROINIT_EN             1
+//   </e>
+
+//   <e0>Message Queue
+//   <i>Exclude Message Queue test cases from the test suite
+//   <i>Message Queue test cases will not appear in test report
+//     <q01>TC_osMessageQueueNew_1
+//     <q02>TC_osMessageQueueNew_2
+//     <q03>TC_osMessageQueueNew_3
+//     <q04>TC_osMessageQueueGetName_1
+//     <q05>TC_osMessageQueuePut_1
+//     <q06>TC_osMessageQueuePut_2
+//     <q07>TC_osMessageQueueGet_1
+//     <q08>TC_osMessageQueueGet_2
+//     <q09>TC_osMessageQueueGetCapacity_1
+//     <q10>TC_osMessageQueueGetMsgSize_1
+//     <q11>TC_osMessageQueueGetCount_1
+//     <q12>TC_osMessageQueueGetSpace_1
+//     <q13>TC_osMessageQueueReset_1
+//     <q14>TC_osMessageQueueDelete_1
+//     <q15>TC_MsgQAllocation
+//     <q16>TC_MsgQBasic
+//     <q17>TC_MsgQWait
+//     <q18>TC_MsgQCheckTimeout
+#define TC_OSMESSAGEQUEUE_EN              1
+#define TC_OSMESSAGEQUEUENEW_1_EN         1
+#define TC_OSMESSAGEQUEUENEW_2_EN         1
+#define TC_OSMESSAGEQUEUENEW_3_EN         1
+#define TC_OSMESSAGEQUEUEGETNAME_1_EN     1
+#define TC_OSMESSAGEQUEUEPUT_1_EN         1
+#define TC_OSMESSAGEQUEUEPUT_2_EN         1
+#define TC_OSMESSAGEQUEUEGET_1_EN         1
+#define TC_OSMESSAGEQUEUEGET_2_EN         1
+#define TC_OSMESSAGEQUEUEGETCAPACITY_1_EN 1
+#define TC_OSMESSAGEQUEUEGETMSGSIZE_1_EN  1
+#define TC_OSMESSAGEQUEUEGETCOUNT_1_EN    1
+#define TC_OSMESSAGEQUEUEGETSPACE_1_EN    1
+#define TC_OSMESSAGEQUEUERESET_1_EN       1
+#define TC_OSMESSAGEQUEUEDELETE_1_EN      1
+#define TC_MSGQALLOCATION_EN              1
+#define TC_MSGQBASIC_EN                   1
+#define TC_MSGQWAIT_EN                    1
+#define TC_MSGQCHECKTIMEOUT_EN            1
+//   </e>
+// </h>
+// </h>
+
+#endif /* RV2_CONFIG_H__ */

--- a/Layer/App/Validation_RTX5/main.c
+++ b/Layer/App/Validation_RTX5/main.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cmsis_rv2.h"
+
+extern int stdio_init (void);
+
+int main (void) {
+  /* Initialize stdio */
+  stdio_init();
+
+  /* CMSIS-RTOS2 validation entry */
+  cmsis_rv2();
+}
+
+#if defined(__GNUC__) && !defined(__CC_ARM) && !defined(__ARMCC_VERSION)
+void _start (void) {
+  main();
+
+  for(;;);
+}
+#endif

--- a/Layer/App/Validation_RTX5/retarget_stdio.c
+++ b/Layer/App/Validation_RTX5/retarget_stdio.c
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------
+ * Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *      Name:    retarget_stdio.c
+ *      Purpose: Retarget stdio to USART
+ *
+ *---------------------------------------------------------------------------*/
+
+#include "Driver_USART.h"
+
+#define USART_DRV_NUM           0
+#define USART_BAUDRATE          115200
+
+#define _USART_Driver_(n)  Driver_USART##n
+#define  USART_Driver_(n) _USART_Driver_(n)
+ 
+extern ARM_DRIVER_USART  USART_Driver_(USART_DRV_NUM);
+#define ptrUSART       (&USART_Driver_(USART_DRV_NUM))
+
+/* Prototypes */
+int stdio_init     (void);
+int stderr_putchar (int ch);
+int stdout_putchar (int ch);
+int stdin_getchar  (void);
+
+/**
+  Initialize stdio
+ 
+  \return          0 on success, or -1 on error.
+*/
+int stdio_init (void) {
+  int32_t status;
+ 
+  status = ptrUSART->Initialize(NULL);
+  if (status != ARM_DRIVER_OK) return (-1);
+ 
+  status = ptrUSART->PowerControl(ARM_POWER_FULL);
+  if (status != ARM_DRIVER_OK) return (-1);
+ 
+  status = ptrUSART->Control(ARM_USART_MODE_ASYNCHRONOUS |
+                             ARM_USART_DATA_BITS_8       |
+                             ARM_USART_PARITY_NONE       |
+                             ARM_USART_STOP_BITS_1       |
+                             ARM_USART_FLOW_CONTROL_NONE,
+                             USART_BAUDRATE);
+  if (status != ARM_DRIVER_OK) return (-1);
+ 
+  status = ptrUSART->Control(ARM_USART_CONTROL_RX, 1);
+  if (status != ARM_DRIVER_OK) return (-1);
+ 
+  return (0);
+}
+
+/**
+  Put a character to the stderr
+ 
+  \param[in]   ch  Character to output
+  \return          The character written, or -1 on write error.
+*/
+int stderr_putchar (int ch) {
+  uint8_t buf[1];
+ 
+  buf[0] = (uint8_t)ch;
+  if (ptrUSART->Send(buf, 1) != ARM_DRIVER_OK) {
+    return (-1);
+  }
+  while (ptrUSART->GetTxCount() != 1);
+  return (ch);
+}
+
+/**
+  Put a character to the stdout
+
+  \param[in]   ch  Character to output
+  \return          The character written, or -1 on write error.
+*/
+int stdout_putchar (int ch) {
+  uint8_t buf[1];
+ 
+  buf[0] = (uint8_t)ch;
+  if (ptrUSART->Send(buf, 1) != ARM_DRIVER_OK) {
+    return (-1);
+  }
+  while (ptrUSART->GetTxCount() != 1);
+  return (ch);
+}
+
+/**
+  Get a character from the stdio
+ 
+  \return     The next character from the input, or -1 on read error.
+*/
+int stdin_getchar (void) {
+  uint8_t buf[1];
+ 
+  if (ptrUSART->Receive(buf, 1) != ARM_DRIVER_OK) {
+    return (-1);
+  }
+  while (ptrUSART->GetRxCount() != 1);
+  return (buf[0]);
+}

--- a/Layer/Target/CM0plus_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM0plus_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM0plus_VHT_AC6/RTE/Device/CMSDK_CM0plus_VHT/RTE_Device.h
+++ b/Layer/Target/CM0plus_VHT_AC6/RTE/Device/CMSDK_CM0plus_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM0plus_VHT_AC6/RTE/Device/CMSDK_CM0plus_VHT/ac6_arm.sct
+++ b/Layer/Target/CM0plus_VHT_AC6/RTE/Device/CMSDK_CM0plus_VHT/ac6_arm.sct
@@ -1,0 +1,76 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m0+ -xc
+; command above MUST be in first line (no comment above!)
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE)    /* starts at end of RAM */
+#define __HEAP_BASE    (AlignExpr(+0, 8))           /* starts after RW_RAM section, 8 byte aligned */
+
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+#define __RO_BASE       __ROM_BASE
+#define __RO_SIZE       __ROM_SIZE
+
+#define __RW_BASE       __RAM_BASE
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE)
+
+
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_RAM __RW_BASE __RW_SIZE  {                     ; RW data
+   .ANY (+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+}

--- a/Layer/Target/CM0plus_VHT_AC6/RTE/Device/CMSDK_CM0plus_VHT/startup_CMSDK_CM0plus.c
+++ b/Layer/Target/CM0plus_VHT_AC6/RTE/Device/CMSDK_CM0plus_VHT/startup_CMSDK_CM0plus.c
@@ -1,0 +1,218 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM0plus.c
+ * @brief    CMSIS Startup File for CMSDK_M0plus Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (CMSDK_CM0plus) || defined (CMSDK_CM0plus_VHT)
+  #include "CMSDK_CM0plus.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM0plus_VHT   /* VSI Interrupts */
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#else
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[48];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[48] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+#if defined CMSDK_CM0plus_VHT
+  ARM_VSI0_Handler,                         /*  24 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /*  25 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /*  26 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /*  27 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /*  28 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /*  29 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /*  30 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /*  31 VSI 7 interrupt */
+#else
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler                           /*  31 GPIO 0 individual interrupt ( 7) */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM0plus_VHT_AC6/RTE/Device/CMSDK_CM0plus_VHT/system_CMSDK_CM0plus.c
+++ b/Layer/Target/CM0plus_VHT_AC6/RTE/Device/CMSDK_CM0plus_VHT/system_CMSDK_CM0plus.c
@@ -1,0 +1,74 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM0plus.c
+ * @brief    CMSIS System Source File for CMSDK_M0plus Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (CMSDK_CM0plus) || defined (CMSDK_CM0plus_VHT)
+  #include "CMSDK_CM0plus.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[48];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM0plus_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM0plus_VHT_AC6/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM0plus_VHT_AC6/vht_config.txt
+++ b/Layer/Target/CM0plus_VHT_AC6/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM0plus_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM0plus_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM0plus_VHT_GCC/RTE/Device/CMSDK_CM0plus_VHT/RTE_Device.h
+++ b/Layer/Target/CM0plus_VHT_GCC/RTE/Device/CMSDK_CM0plus_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM0plus_VHT_GCC/RTE/Device/CMSDK_CM0plus_VHT/gcc_arm.ld
+++ b/Layer/Target/CM0plus_VHT_GCC/RTE/Device/CMSDK_CM0plus_VHT/gcc_arm.ld
@@ -1,0 +1,279 @@
+/******************************************************************************
+ * @file     gcc_arm.ld
+ * @brief    GNU Linker Script for Cortex-M based device
+ ******************************************************************************/
+
+/*
+; -------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__ROM_BASE = 0x00000000;
+__ROM_SIZE = 0x00040000;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ -----------------------------------------------------------------------------*/
+__RAM_BASE = 0x20000000;
+__RAM_SIZE = 0x00020000;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00000400;
+__HEAP_SIZE  = 0x00000C00;
+
+/*
+; -------------------- <<< end of configuration section >>> -------------------
+ */
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  /*
+   * SG veneers:
+   * All SG veneers are placed in the special output section .gnu.sgstubs. Its start address
+   * must be set, either with the command line option ‘--section-start’ or in a linker script,
+   * to indicate where to place these veneers in memory.
+   */
+/*
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > FLASH
+*/
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__) / 4)
+    /* Add each additional bss section here */
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /**
+   * Location counter can end up 2byte aligned with narrow Thumb code but
+   * __etext is assumed by startup code to be the LMA of a section in RAM
+   * which must be 4byte aligned
+   */
+  __etext = ALIGN (4);
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  __etext2 = ALIGN (4);
+
+  .data2 : AT (__etext2)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (COPY) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/Layer/Target/CM0plus_VHT_GCC/RTE/Device/CMSDK_CM0plus_VHT/startup_CMSDK_CM0plus.c
+++ b/Layer/Target/CM0plus_VHT_GCC/RTE/Device/CMSDK_CM0plus_VHT/startup_CMSDK_CM0plus.c
@@ -1,0 +1,218 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM0plus.c
+ * @brief    CMSIS Startup File for CMSDK_M0plus Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (CMSDK_CM0plus) || defined (CMSDK_CM0plus_VHT)
+  #include "CMSDK_CM0plus.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM0plus_VHT   /* VSI Interrupts */
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#else
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[48];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[48] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+#if defined CMSDK_CM0plus_VHT
+  ARM_VSI0_Handler,                         /*  24 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /*  25 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /*  26 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /*  27 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /*  28 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /*  29 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /*  30 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /*  31 VSI 7 interrupt */
+#else
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler                           /*  31 GPIO 0 individual interrupt ( 7) */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM0plus_VHT_GCC/RTE/Device/CMSDK_CM0plus_VHT/system_CMSDK_CM0plus.c
+++ b/Layer/Target/CM0plus_VHT_GCC/RTE/Device/CMSDK_CM0plus_VHT/system_CMSDK_CM0plus.c
@@ -1,0 +1,74 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM0plus.c
+ * @brief    CMSIS System Source File for CMSDK_M0plus Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (CMSDK_CM0plus) || defined (CMSDK_CM0plus_VHT)
+  #include "CMSDK_CM0plus.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[48];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM0plus_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM0plus_VHT_GCC/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM0plus_VHT_GCC/vht_config.txt
+++ b/Layer/Target/CM0plus_VHT_GCC/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM23_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM23_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   NONSEC_WATCHDOG_RESET_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       0
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   NONSEC_WATCHDOG_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       1
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/RTE_Device.h
+++ b/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/ac6_arm.sct
+++ b/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/ac6_arm.sct
@@ -1,0 +1,119 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m23 -xc -mcmse
+; command above MUST be in first line (no comment above!)
+
+;Note: Add '-mcmse' to first line if your software model is "Secure Mode".
+;      #! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m23 -xc -mcmse
+
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x10000000
+#define __ROM_SIZE      0x00200000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x38000000
+#define __RAM_SIZE      0x00200000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000400
+#define __HEAP_SIZE     0x00000C00
+
+/*--------------------- CMSE Venner Configuration ---------------------------
+; <h> CMSE Venner Configuration
+;   <o0>  CMSE Venner Size (in Bytes) <0x0-0xFFFFFFFF:32>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __CMSEVENEER_SIZE    0x200
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE - __STACKSEAL_SIZE) /* starts at end of RAM - 8 byte stack seal */
+#define __HEAP_BASE    (AlignExpr(+0, 8))                           /* starts after RW_RAM section, 8 byte aligned */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Region base & size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __CV_BASE          ( __ROM_BASE + __ROM_SIZE - __CMSEVENEER_SIZE )
+#define __CV_SIZE          ( __CMSEVENEER_SIZE )
+#else
+#define __CV_SIZE          ( 0 )
+#endif
+
+#define __RO_BASE          ( __ROM_BASE )
+#define __RO_SIZE          ( __ROM_SIZE - __CV_SIZE )
+
+#define __RW_BASE          ( __RAM_BASE )
+#define __RW_SIZE          ( __RAM_SIZE - __STACK_SIZE - __HEAP_SIZE )
+
+
+/*----------------------------------------------------------------------------
+  Scatter Region definition
+ *----------------------------------------------------------------------------*/
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_RAM __RW_BASE __RW_SIZE  {                     ; RW data
+   .ANY (+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+LR_CMSE_VENEER __CV_BASE ALIGN 32 __CV_SIZE  {      ; own load/execution region for CMSE Venners
+  ER_CMSE_VENEER __CV_BASE __CV_SIZE  {
+   *(Veneer$$CMSE)
+  }
+}
+#endif

--- a/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/partition_IOTKit_CM23.h
+++ b/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/partition_IOTKit_CM23.h
@@ -1,0 +1,585 @@
+/******************************************************************************
+ * @file     partition_IOTKit_CM23.h
+ * @brief    CMSIS-Core Initial Setup for Secure / Non-Secure Zones for IOTKit_CM23
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#ifndef PARTITION_IOTKit_CM23_H
+#define PARTITION_IOTKit_CM23_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          0
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x10000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x101FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x28200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x283FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x403FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  0
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    0
+
+/*
+// Interrupts 0..31
+//   <o.0>  Non-Secure Watchdog Reset Request      <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Non-Secure Watchdog interrupt          <0=> Secure state <1=> Non-Secure state
+//   <o.2>  S32K Timer interrupt                   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Timer 0 interrupt                      <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Timer 1 interrupt                      <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Dual Timer interrupt                   <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    0
+
+/*
+// Interrupts 32..63
+//   <o.0>  UART 0 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.1>  UART 0 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.2>  UART 1 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.3>  UART 1 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.4>  UART 2 teceive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.5>  UART 2 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.6>  UART 3 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.7>  UART 3 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.8>  UART 4 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.9>  UART 4 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.10> UART 0 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.11> UART 1 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.12> UART 2 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.13> UART 3 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.14> UART 4 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.15> UART 0, 1, 2, 3, 4 overflow interrupt  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Ethernet interrupt                     <0=> Secure state <1=> Non-Secure state
+//   <o.17> Audio I2S interrupt                    <0=> Secure state <1=> Non-Secure state
+//   <o.18> Touch Screen interrupt                 <0=> Secure state <1=> Non-Secure state
+//   <o.19> SPI 0 (SPI Header) interrupt           <0=> Secure state <1=> Non-Secure state
+//   <o.20> SPI 1 (CLCD) interrupt                 <0=> Secure state <1=> Non-Secure state
+//   <o.21> SPI 2 (Shield ADC) interrupt           <0=> Secure state <1=> Non-Secure state
+//   <o.22> SPI 3 (Shield 0 SPI) interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.23> SPI 4 (Shield 1 SPI) interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.24> DMA 0 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.25> DMA 0 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.26> DMA 0 combined interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.27> DMA 1 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.28> DMA 1 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.29> DMA 1 combined interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.30> DMA 2 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.31> DMA 2 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  DMA 2 combined interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.1>  DMA 3 error interrupt            <0=> Secure state <1=> Non-Secure state
+//   <o.2>  DMA 3 terminal count interrupt   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  DMA 3 combined interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.4>  GPIO 0 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.5>  GPIO 1 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.6>  GPIO 2 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.7>  GPIO 3 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.8>  GPIO 0 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.9>  GPIO 0 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.10> GPIO 0 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.11> GPIO 0 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.12> GPIO 0 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.13> GPIO 0 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.14> GPIO 0 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.15> GPIO 0 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+//   <o.16> GPIO 0 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.17> GPIO 0 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.18> GPIO 0 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.19> GPIO 0 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.20> GPIO 0 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.21> GPIO 0 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.22> GPIO 0 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.23> GPIO 0 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.24> GPIO 1 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.25> GPIO 1 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.26> GPIO 1 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.27> GPIO 1 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.28> GPIO 1 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.29> GPIO 1 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.30> GPIO 1 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.31> GPIO 1 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  GPIO 1 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.1>  GPIO 1 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.2>  GPIO 1 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.3>  GPIO 1 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.4>  GPIO 1 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.5>  GPIO 1 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.6>  GPIO 1 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.7>  GPIO 1 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.8>  GPIO 2 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.9>  GPIO 2 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.10> GPIO 2 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.11> GPIO 2 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.12> GPIO 2 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.13> GPIO 2 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.14> GPIO 2 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.15> GPIO 2 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+//   <o.16> GPIO 2 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.17> GPIO 2 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.18> GPIO 2 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.19> GPIO 2 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.20> GPIO 2 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.21> GPIO 2 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.22> GPIO 2 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.23> GPIO 2 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.24> GPIO 3 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.25> GPIO 3 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.26> GPIO 3 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.27> GPIO 3 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk |  SCB_AIRCR_PRIS_Msk)        )                     |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_IOTKit_CM23_H */

--- a/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/startup_IOTKit_CM23.c
+++ b/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/startup_IOTKit_CM23.c
@@ -1,0 +1,506 @@
+/******************************************************************************
+ * @file     startup_IOTKit_CM23.c
+ * @brief    CMSIS Startup File for IOTKit_CM23 Device
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (IOTKit_CM23) || defined (IOTKit_CM23_VHT)
+  #include "IOTKit_CM23.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler               (void) __attribute__ ((weak));
+void SVC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Core IoT Interrupts */
+void NONSEC_WATCHDOG_RESET_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void NONSEC_WATCHDOG_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void S32K_TIMER_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler               (void) __attribute__ ((weak, alias("Default_Handler")));
+void MPC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void PPC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void MSC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void BRIDGE_ERROR_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* External Interrupts */
+void UART0RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UARTOVF_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void TSC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI0_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI1_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI2_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI3_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI4_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* VSI Interrupts */
+#if defined (IOTKit_CM23_VHT)
+void ARM_VSI0_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Core IoT Interrupts */
+  NONSEC_WATCHDOG_RESET_Handler,            /*   0 Non-Secure Watchdog Reset Handler */
+  NONSEC_WATCHDOG_Handler,                  /*   1 Non-Secure Watchdog Handler */
+  S32K_TIMER_Handler,                       /*   2 S32K Timer Handler */
+  TIMER0_Handler,                           /*   3 TIMER 0 Handler */
+  TIMER1_Handler,                           /*   4 TIMER 1 Handler */
+  DUALTIMER_Handler,                        /*   5 Dual Timer Handler */
+  0,                                        /*   6 Reserved */
+  0,                                        /*   7 Reserved */
+  0,                                        /*   8 Reserved */
+  MPC_Handler,                              /*   9 MPC Combined (Secure) Handler */
+  PPC_Handler,                              /*  10 PPC Combined (Secure) Handler */
+  MSC_Handler,                              /*  11 MSC Combined (Secure) Handler */
+  BRIDGE_ERROR_Handler,                     /*  12 Bridge Error Combined (Secure) Handler */
+  0,                                        /*  13 Reserved */
+  0,                                        /*  14 Reserved */
+  0,                                        /*  15 Reserved */
+  0,                                        /*  16 Reserved */
+  0,                                        /*  17 Reserved */
+  0,                                        /*  18 Reserved */
+  0,                                        /*  19 Reserved */
+  0,                                        /*  20 Reserved */
+  0,                                        /*  21 Reserved */
+  0,                                        /*  22 Reserved */
+  0,                                        /*  23 Reserved */
+  0,                                        /*  24 Reserved */
+  0,                                        /*  25 Reserved */
+  0,                                        /*  26 Reserved */
+  0,                                        /*  27 Reserved */
+  0,                                        /*  28 Reserved */
+  0,                                        /*  29 Reserved */
+  0,                                        /*  30 Reserved */
+  0,                                        /*  31 Reserved */
+
+  /* External Interrupts */
+  UART0RX_Handler,                          /*  32 UART 0 RX Handler */
+  UART0TX_Handler,                          /*  33 UART 0 TX Handler */
+  UART1RX_Handler,                          /*  34 UART 1 RX Handler */
+  UART1TX_Handler,                          /*  35 UART 1 TX Handler */
+  UART2RX_Handler,                          /*  36 UART 2 RX Handler */
+  UART2TX_Handler,                          /*  37 UART 2 TX Handler */
+  UART3RX_Handler,                          /*  38 UART 2 RX Handler */
+  UART3TX_Handler,                          /*  39 UART 2 TX Handler */
+  UART4RX_Handler,                          /*  40 UART 2 RX Handler */
+  UART4TX_Handler,                          /*  41 UART 2 TX Handler */
+  UART0_Handler,                            /*  42 UART 0 combined Handler */
+  UART1_Handler,                            /*  43 UART 1 combined Handler */
+  UART2_Handler,                            /*  44 UART 2 combined Handler */
+  UART3_Handler,                            /*  45 UART 3 combined Handler */
+  UART4_Handler,                            /*  46 UART 4 combined Handler */
+  UARTOVF_Handler,                          /*  47 UART 0,1,2,3,4 Overflow Handler */
+  ETHERNET_Handler ,                        /*  48 Ethernet Handler */
+  I2S_Handler,                              /*  49 I2S Handler */
+  TSC_Handler,                              /*  50 Touch Screen Handler */
+  SPI0_Handler,                             /*  51 SPI 0 Handler */
+  SPI1_Handler,                             /*  52 SPI 1 Handler */
+  SPI2_Handler,                             /*  53 SPI 2 Handler */
+  SPI3_Handler,                             /*  54 SPI 3 Handler */
+  SPI4_Handler,                             /*  55 SPI 4 Handler */
+  DMA0_ERROR_Handler,                       /*  56 DMA 0 Error Handler */
+  DMA0_TC_Handler,                          /*  57 DMA 0 Terminal Count Handler */
+  DMA0_Handler,                             /*  58 DMA 0 Combined Handler */
+  DMA1_ERROR_Handler,                       /*  59 DMA 1 Error Handler */
+  DMA1_TC_Handler,                          /*  60 DMA 1 Terminal Count Handler */
+  DMA1_Handler,                             /*  61 DMA 1 Combined Handler */
+  DMA2_ERROR_Handler,                       /*  62 DMA 2 Error Handler */
+  DMA2_TC_Handler,                          /*  63 DMA 2 Terminal Count Handler */
+  DMA2_Handler,                             /*  64 DMA 2 Combined Handler */
+  DMA3_ERROR_Handler,                       /*  65 DMA 3 Error Handler */
+  DMA3_TC_Handler,                          /*  66 DMA 3 Terminal Count Handler */
+  DMA3_Handler,                             /*  67 DMA 3 Combined Handler */
+  GPIO0_Handler,                            /*  68 GPIO 0 Combined Handler */
+  GPIO1_Handler,                            /*  69 GPIO 1 Combined Handler */
+  GPIO2_Handler,                            /*  70 GPIO 2 Combined Handler */
+  GPIO3_Handler,                            /*  71 GPIO 3 Combined Handler */
+  GPIO0_0_Handler,                          /*  72 */      /* All P0 I/O pins used as irq source */
+  GPIO0_1_Handler,                          /*  73 */      /* There are 16 pins in total         */
+  GPIO0_2_Handler,                          /*  74 */
+  GPIO0_3_Handler,                          /*  75 */
+  GPIO0_4_Handler,                          /*  76 */
+  GPIO0_5_Handler,                          /*  77 */
+  GPIO0_6_Handler,                          /*  78 */
+  GPIO0_7_Handler,                          /*  79 */
+  GPIO0_8_Handler,                          /*  80 */
+  GPIO0_9_Handler,                          /*  81 */
+  GPIO0_10_Handler,                         /*  82 */
+  GPIO0_11_Handler,                         /*  83 */
+  GPIO0_12_Handler,                         /*  84 */
+  GPIO0_13_Handler,                         /*  85 */
+  GPIO0_14_Handler,                         /*  86 */
+  GPIO0_15_Handler,                         /*  87 */
+  GPIO1_0_Handler,                          /*  88 */      /* All P1 I/O pins used as irq source */
+  GPIO1_1_Handler,                          /*  89 */      /* There are 16 pins in total         */
+  GPIO1_2_Handler,                          /*  90 */
+  GPIO1_3_Handler,                          /*  91 */
+  GPIO1_4_Handler,                          /*  92 */
+  GPIO1_5_Handler,                          /*  93 */
+  GPIO1_6_Handler,                          /*  94 */
+  GPIO1_7_Handler,                          /*  95 */
+  GPIO1_8_Handler,                          /*  96 */
+  GPIO1_9_Handler,                          /*  97 */
+  GPIO1_10_Handler,                         /*  98 */
+  GPIO1_11_Handler,                         /*  99 */
+  GPIO1_12_Handler,                         /* 100 */
+  GPIO1_13_Handler,                         /* 101 */
+  GPIO1_14_Handler,                         /* 102 */
+  GPIO1_15_Handler,                         /* 103 */
+  GPIO2_0_Handler,                          /* 104 */      /* All P2 I/O pins used as irq source */
+  GPIO2_1_Handler,                          /* 105 */      /* There are 16 pins in total         */
+  GPIO2_2_Handler,                          /* 106 */
+  GPIO2_3_Handler,                          /* 107 */
+  GPIO2_4_Handler,                          /* 108 */
+  GPIO2_5_Handler,                          /* 109 */
+  GPIO2_6_Handler,                          /* 110 */
+  GPIO2_7_Handler,                          /* 111 */
+  GPIO2_8_Handler,                          /* 112 */
+  GPIO2_9_Handler,                          /* 113 */
+  GPIO2_10_Handler,                         /* 114 */
+  GPIO2_11_Handler,                         /* 115 */
+  GPIO2_12_Handler,                         /* 116 */
+  GPIO2_13_Handler,                         /* 117 */
+  GPIO2_14_Handler,                         /* 118 */
+  GPIO2_15_Handler,                         /* 119 */
+  GPIO3_0_Handler,                          /* 120 */      /* All P3 I/O pins used as irq source */
+  GPIO3_1_Handler,                          /* 121 */      /* There are 4 pins in total          */
+  GPIO3_2_Handler,                          /* 122 */
+  GPIO3_3_Handler,                          /* 123 */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined (IOTKit_CM23_VHT)
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/system_IOTKit_CM23.c
+++ b/Layer/Target/CM23_VHT_AC6/RTE/Device/IOTKit_CM23_VHT/system_IOTKit_CM23.c
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * @file     system_IOTKit_CM23.c
+ * @brief    CMSIS Device System Source File for IOTKit_CM23 Device
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (IOTKit_CM23) || defined (IOTKit_CM23_VHT)
+  #include "IOTKit_CM23.h"
+#else
+  #error device not specified!
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+  #include "partition_IOTKit_CM23.h"
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+//  uint32_t blk_cfg, blk_max, blk_size, blk_cnt;
+#endif
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/* start IOT Green configuration ------------------------- */
+
+  /* configure MPC --------------- */
+
+  /* configure unsecure code area MPSSSRAM1 (0x00200000 - 0x003FFFFF) */
+//  blk_max = IOTKIT_MPCSSRAM1->BLK_MAX;   /* = 0x1     */
+//  blk_cfg = IOTKIT_MPCSSRAM1->BLK_CFG;   /* = 0xC     */
+//  blk_size = 1UL << (blk_cfg + 5U);      /* = 0x20000 */
+//  blk_cnt  = 0x200000U / blk_size;       /* = 0x10    */
+
+  IOTKIT_MPCSSRAM1->CTRL    &= ~(1UL << 8U);            /* clear auto increment */
+  IOTKIT_MPCSSRAM1->BLK_IDX  = 0;                       /* write LUT index */
+  IOTKIT_MPCSSRAM1->BLK_LUT  = 0xFFFF0000UL;            /* configure blocks */
+
+
+  /* configure unsecure data area MPSSSRAM3 (0x28200000 - 0x283FFFFF) */
+//  blk_max = IOTKIT_MPCSSRAM3->BLK_MAX;   /* = 0x1     */
+//  blk_cfg = IOTKIT_MPCSSRAM3->BLK_CFG;   /* = 0xB     */
+//  blk_size = 1UL << (blk_cfg + 5U);      /* = 0x10000 */
+//  blk_cnt  = 0x200000U / blk_size;       /* = 0x20    */
+
+  IOTKIT_MPCSSRAM3->CTRL &= ~(1UL << 8U);              /* clear auto increment */
+  IOTKIT_MPCSSRAM3->BLK_IDX = 1;                       /* write LUT index */
+  IOTKIT_MPCSSRAM3->BLK_LUT = 0xFFFFFFFFUL;            /* configure blocks */
+
+
+
+  /* enable the Non Secure Callable Configuration for IDAU (NSCCFG register) */
+  IOTKIT_SPC->NSCCFG |= 1U;
+
+
+  /* configure PPC --------------- */
+#if !defined (__USE_SECURE)
+  /* Allow Non-secure access for SCC/FPGAIO registers */
+  IOTKIT_SPC->APBNSPPCEXP[2U] |= ((1UL << 0U) |
+                                  (1UL << 2U)  );
+  /* Allow Non-secure access for SPI1/UART0 registers */
+  IOTKIT_SPC->APBNSPPCEXP[1U] |= ((1UL << 1U) |
+                                  (1UL << 5U)  );
+#endif
+
+/* end IOT Green configuration --------------------------- */
+
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM23_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM23_VHT_AC6/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2 IOT-Kit:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM23_VHT_AC6/vht_config.txt
+++ b/Layer/Target/CM23_VHT_AC6/vht_config.txt
@@ -1,0 +1,27 @@
+## Parameters:
+## instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+##------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+##------------------------------------------------------------------------------
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+cpu0.BE=0                                             # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.INITVTOR=0                                       # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset
+cpu0.INITVTORNS=0                                     # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored
+cpu0.SAU=4                                            # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU)
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+cpu0.SYST=2                                           # (int   , init-time) default = '0x2'    : Include SysTick timer functionality (0=Absent, 1=Secure only, 2=Secure and NS)
+cpu0.VTOR=1                                           # (bool  , init-time) default = '1'      : Include Vector Table Offset Register
+cpu0.semihosting-enable=0                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+fvp_mps2.platform_type=1                              # (int   , init-time) default = '0x0'    : 0:Original MPS2 ; 1:IoT Kit (cut-down SSE-200) ; 2:Full SSE-200; 3:SVOS
+idau.NUM_IDAU_REGION=0                                # (int   , init-time) default = '0x12'   : 
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM23_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM23_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   NONSEC_WATCHDOG_RESET_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       0
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   NONSEC_WATCHDOG_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       1
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/RTE_Device.h
+++ b/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/gcc_arm.ld
+++ b/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/gcc_arm.ld
@@ -1,0 +1,301 @@
+/******************************************************************************
+ * @file     gcc_arm.ld
+ * @brief    GNU Linker Script for Cortex-M based device
+ ******************************************************************************/
+
+/*
+; -------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__ROM_BASE = 0x10000000;
+__ROM_SIZE = 0x00200000;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ -----------------------------------------------------------------------------*/
+__RAM_BASE = 0x38000000;
+__RAM_SIZE = 0x00200000;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00000400;
+__HEAP_SIZE  = 0x00000C00;
+
+/*
+; -------------------- <<< end of configuration section >>> -------------------
+ */
+
+/* ARMv8-M stack sealing:
+   to use ARMv8-M stack sealing set __STACKSEAL_SIZE to 8 otherwise keep 0
+ */
+__STACKSEAL_SIZE = 8;
+
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __StackSeal      (only if ARMv8-M stack sealing is used)
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  /*
+   * SG veneers:
+   * All SG veneers are placed in the special output section .gnu.sgstubs. Its start address
+   * must be set, either with the command line option ‘--section-start’ or in a linker script,
+   * to indicate where to place these veneers in memory.
+   */
+/*
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > FLASH
+*/
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__) / 4)
+
+    /* Add each additional bss section here */
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /**
+   * Location counter can end up 2byte aligned with narrow Thumb code but
+   * __etext is assumed by startup code to be the LMA of a section in RAM
+   * which must be 4byte aligned
+   */
+  __etext = ALIGN (4);
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  __etext2 = ALIGN (4);
+
+  .data2 : AT (__etext2)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (COPY) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE - __STACKSEAL_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+  
+  /* ARMv8-M stack sealing:
+     to use ARMv8-M stack sealing uncomment '.stackseal' section
+   */
+
+  .stackseal (ORIGIN(RAM) + LENGTH(RAM) - __STACKSEAL_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM
+
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/partition_IOTKit_CM23.h
+++ b/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/partition_IOTKit_CM23.h
@@ -1,0 +1,585 @@
+/******************************************************************************
+ * @file     partition_IOTKit_CM23.h
+ * @brief    CMSIS-Core Initial Setup for Secure / Non-Secure Zones for IOTKit_CM23
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#ifndef PARTITION_IOTKit_CM23_H
+#define PARTITION_IOTKit_CM23_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          0
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x10000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x101FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x28200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x283FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x403FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  0
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    0
+
+/*
+// Interrupts 0..31
+//   <o.0>  Non-Secure Watchdog Reset Request      <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Non-Secure Watchdog interrupt          <0=> Secure state <1=> Non-Secure state
+//   <o.2>  S32K Timer interrupt                   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Timer 0 interrupt                      <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Timer 1 interrupt                      <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Dual Timer interrupt                   <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    0
+
+/*
+// Interrupts 32..63
+//   <o.0>  UART 0 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.1>  UART 0 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.2>  UART 1 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.3>  UART 1 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.4>  UART 2 teceive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.5>  UART 2 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.6>  UART 3 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.7>  UART 3 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.8>  UART 4 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.9>  UART 4 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.10> UART 0 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.11> UART 1 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.12> UART 2 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.13> UART 3 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.14> UART 4 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.15> UART 0, 1, 2, 3, 4 overflow interrupt  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Ethernet interrupt                     <0=> Secure state <1=> Non-Secure state
+//   <o.17> Audio I2S interrupt                    <0=> Secure state <1=> Non-Secure state
+//   <o.18> Touch Screen interrupt                 <0=> Secure state <1=> Non-Secure state
+//   <o.19> SPI 0 (SPI Header) interrupt           <0=> Secure state <1=> Non-Secure state
+//   <o.20> SPI 1 (CLCD) interrupt                 <0=> Secure state <1=> Non-Secure state
+//   <o.21> SPI 2 (Shield ADC) interrupt           <0=> Secure state <1=> Non-Secure state
+//   <o.22> SPI 3 (Shield 0 SPI) interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.23> SPI 4 (Shield 1 SPI) interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.24> DMA 0 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.25> DMA 0 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.26> DMA 0 combined interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.27> DMA 1 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.28> DMA 1 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.29> DMA 1 combined interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.30> DMA 2 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.31> DMA 2 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  DMA 2 combined interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.1>  DMA 3 error interrupt            <0=> Secure state <1=> Non-Secure state
+//   <o.2>  DMA 3 terminal count interrupt   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  DMA 3 combined interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.4>  GPIO 0 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.5>  GPIO 1 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.6>  GPIO 2 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.7>  GPIO 3 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.8>  GPIO 0 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.9>  GPIO 0 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.10> GPIO 0 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.11> GPIO 0 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.12> GPIO 0 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.13> GPIO 0 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.14> GPIO 0 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.15> GPIO 0 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+//   <o.16> GPIO 0 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.17> GPIO 0 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.18> GPIO 0 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.19> GPIO 0 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.20> GPIO 0 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.21> GPIO 0 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.22> GPIO 0 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.23> GPIO 0 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.24> GPIO 1 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.25> GPIO 1 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.26> GPIO 1 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.27> GPIO 1 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.28> GPIO 1 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.29> GPIO 1 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.30> GPIO 1 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.31> GPIO 1 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  GPIO 1 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.1>  GPIO 1 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.2>  GPIO 1 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.3>  GPIO 1 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.4>  GPIO 1 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.5>  GPIO 1 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.6>  GPIO 1 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.7>  GPIO 1 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.8>  GPIO 2 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.9>  GPIO 2 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.10> GPIO 2 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.11> GPIO 2 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.12> GPIO 2 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.13> GPIO 2 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.14> GPIO 2 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.15> GPIO 2 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+//   <o.16> GPIO 2 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.17> GPIO 2 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.18> GPIO 2 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.19> GPIO 2 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.20> GPIO 2 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.21> GPIO 2 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.22> GPIO 2 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.23> GPIO 2 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.24> GPIO 3 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.25> GPIO 3 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.26> GPIO 3 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.27> GPIO 3 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk |  SCB_AIRCR_PRIS_Msk)        )                     |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_IOTKit_CM23_H */

--- a/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/startup_IOTKit_CM23.c
+++ b/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/startup_IOTKit_CM23.c
@@ -1,0 +1,506 @@
+/******************************************************************************
+ * @file     startup_IOTKit_CM23.c
+ * @brief    CMSIS Startup File for IOTKit_CM23 Device
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (IOTKit_CM23) || defined (IOTKit_CM23_VHT)
+  #include "IOTKit_CM23.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler               (void) __attribute__ ((weak));
+void SVC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Core IoT Interrupts */
+void NONSEC_WATCHDOG_RESET_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void NONSEC_WATCHDOG_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void S32K_TIMER_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler               (void) __attribute__ ((weak, alias("Default_Handler")));
+void MPC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void PPC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void MSC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void BRIDGE_ERROR_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* External Interrupts */
+void UART0RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UARTOVF_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void TSC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI0_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI1_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI2_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI3_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI4_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* VSI Interrupts */
+#if defined (IOTKit_CM23_VHT)
+void ARM_VSI0_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Core IoT Interrupts */
+  NONSEC_WATCHDOG_RESET_Handler,            /*   0 Non-Secure Watchdog Reset Handler */
+  NONSEC_WATCHDOG_Handler,                  /*   1 Non-Secure Watchdog Handler */
+  S32K_TIMER_Handler,                       /*   2 S32K Timer Handler */
+  TIMER0_Handler,                           /*   3 TIMER 0 Handler */
+  TIMER1_Handler,                           /*   4 TIMER 1 Handler */
+  DUALTIMER_Handler,                        /*   5 Dual Timer Handler */
+  0,                                        /*   6 Reserved */
+  0,                                        /*   7 Reserved */
+  0,                                        /*   8 Reserved */
+  MPC_Handler,                              /*   9 MPC Combined (Secure) Handler */
+  PPC_Handler,                              /*  10 PPC Combined (Secure) Handler */
+  MSC_Handler,                              /*  11 MSC Combined (Secure) Handler */
+  BRIDGE_ERROR_Handler,                     /*  12 Bridge Error Combined (Secure) Handler */
+  0,                                        /*  13 Reserved */
+  0,                                        /*  14 Reserved */
+  0,                                        /*  15 Reserved */
+  0,                                        /*  16 Reserved */
+  0,                                        /*  17 Reserved */
+  0,                                        /*  18 Reserved */
+  0,                                        /*  19 Reserved */
+  0,                                        /*  20 Reserved */
+  0,                                        /*  21 Reserved */
+  0,                                        /*  22 Reserved */
+  0,                                        /*  23 Reserved */
+  0,                                        /*  24 Reserved */
+  0,                                        /*  25 Reserved */
+  0,                                        /*  26 Reserved */
+  0,                                        /*  27 Reserved */
+  0,                                        /*  28 Reserved */
+  0,                                        /*  29 Reserved */
+  0,                                        /*  30 Reserved */
+  0,                                        /*  31 Reserved */
+
+  /* External Interrupts */
+  UART0RX_Handler,                          /*  32 UART 0 RX Handler */
+  UART0TX_Handler,                          /*  33 UART 0 TX Handler */
+  UART1RX_Handler,                          /*  34 UART 1 RX Handler */
+  UART1TX_Handler,                          /*  35 UART 1 TX Handler */
+  UART2RX_Handler,                          /*  36 UART 2 RX Handler */
+  UART2TX_Handler,                          /*  37 UART 2 TX Handler */
+  UART3RX_Handler,                          /*  38 UART 2 RX Handler */
+  UART3TX_Handler,                          /*  39 UART 2 TX Handler */
+  UART4RX_Handler,                          /*  40 UART 2 RX Handler */
+  UART4TX_Handler,                          /*  41 UART 2 TX Handler */
+  UART0_Handler,                            /*  42 UART 0 combined Handler */
+  UART1_Handler,                            /*  43 UART 1 combined Handler */
+  UART2_Handler,                            /*  44 UART 2 combined Handler */
+  UART3_Handler,                            /*  45 UART 3 combined Handler */
+  UART4_Handler,                            /*  46 UART 4 combined Handler */
+  UARTOVF_Handler,                          /*  47 UART 0,1,2,3,4 Overflow Handler */
+  ETHERNET_Handler ,                        /*  48 Ethernet Handler */
+  I2S_Handler,                              /*  49 I2S Handler */
+  TSC_Handler,                              /*  50 Touch Screen Handler */
+  SPI0_Handler,                             /*  51 SPI 0 Handler */
+  SPI1_Handler,                             /*  52 SPI 1 Handler */
+  SPI2_Handler,                             /*  53 SPI 2 Handler */
+  SPI3_Handler,                             /*  54 SPI 3 Handler */
+  SPI4_Handler,                             /*  55 SPI 4 Handler */
+  DMA0_ERROR_Handler,                       /*  56 DMA 0 Error Handler */
+  DMA0_TC_Handler,                          /*  57 DMA 0 Terminal Count Handler */
+  DMA0_Handler,                             /*  58 DMA 0 Combined Handler */
+  DMA1_ERROR_Handler,                       /*  59 DMA 1 Error Handler */
+  DMA1_TC_Handler,                          /*  60 DMA 1 Terminal Count Handler */
+  DMA1_Handler,                             /*  61 DMA 1 Combined Handler */
+  DMA2_ERROR_Handler,                       /*  62 DMA 2 Error Handler */
+  DMA2_TC_Handler,                          /*  63 DMA 2 Terminal Count Handler */
+  DMA2_Handler,                             /*  64 DMA 2 Combined Handler */
+  DMA3_ERROR_Handler,                       /*  65 DMA 3 Error Handler */
+  DMA3_TC_Handler,                          /*  66 DMA 3 Terminal Count Handler */
+  DMA3_Handler,                             /*  67 DMA 3 Combined Handler */
+  GPIO0_Handler,                            /*  68 GPIO 0 Combined Handler */
+  GPIO1_Handler,                            /*  69 GPIO 1 Combined Handler */
+  GPIO2_Handler,                            /*  70 GPIO 2 Combined Handler */
+  GPIO3_Handler,                            /*  71 GPIO 3 Combined Handler */
+  GPIO0_0_Handler,                          /*  72 */      /* All P0 I/O pins used as irq source */
+  GPIO0_1_Handler,                          /*  73 */      /* There are 16 pins in total         */
+  GPIO0_2_Handler,                          /*  74 */
+  GPIO0_3_Handler,                          /*  75 */
+  GPIO0_4_Handler,                          /*  76 */
+  GPIO0_5_Handler,                          /*  77 */
+  GPIO0_6_Handler,                          /*  78 */
+  GPIO0_7_Handler,                          /*  79 */
+  GPIO0_8_Handler,                          /*  80 */
+  GPIO0_9_Handler,                          /*  81 */
+  GPIO0_10_Handler,                         /*  82 */
+  GPIO0_11_Handler,                         /*  83 */
+  GPIO0_12_Handler,                         /*  84 */
+  GPIO0_13_Handler,                         /*  85 */
+  GPIO0_14_Handler,                         /*  86 */
+  GPIO0_15_Handler,                         /*  87 */
+  GPIO1_0_Handler,                          /*  88 */      /* All P1 I/O pins used as irq source */
+  GPIO1_1_Handler,                          /*  89 */      /* There are 16 pins in total         */
+  GPIO1_2_Handler,                          /*  90 */
+  GPIO1_3_Handler,                          /*  91 */
+  GPIO1_4_Handler,                          /*  92 */
+  GPIO1_5_Handler,                          /*  93 */
+  GPIO1_6_Handler,                          /*  94 */
+  GPIO1_7_Handler,                          /*  95 */
+  GPIO1_8_Handler,                          /*  96 */
+  GPIO1_9_Handler,                          /*  97 */
+  GPIO1_10_Handler,                         /*  98 */
+  GPIO1_11_Handler,                         /*  99 */
+  GPIO1_12_Handler,                         /* 100 */
+  GPIO1_13_Handler,                         /* 101 */
+  GPIO1_14_Handler,                         /* 102 */
+  GPIO1_15_Handler,                         /* 103 */
+  GPIO2_0_Handler,                          /* 104 */      /* All P2 I/O pins used as irq source */
+  GPIO2_1_Handler,                          /* 105 */      /* There are 16 pins in total         */
+  GPIO2_2_Handler,                          /* 106 */
+  GPIO2_3_Handler,                          /* 107 */
+  GPIO2_4_Handler,                          /* 108 */
+  GPIO2_5_Handler,                          /* 109 */
+  GPIO2_6_Handler,                          /* 110 */
+  GPIO2_7_Handler,                          /* 111 */
+  GPIO2_8_Handler,                          /* 112 */
+  GPIO2_9_Handler,                          /* 113 */
+  GPIO2_10_Handler,                         /* 114 */
+  GPIO2_11_Handler,                         /* 115 */
+  GPIO2_12_Handler,                         /* 116 */
+  GPIO2_13_Handler,                         /* 117 */
+  GPIO2_14_Handler,                         /* 118 */
+  GPIO2_15_Handler,                         /* 119 */
+  GPIO3_0_Handler,                          /* 120 */      /* All P3 I/O pins used as irq source */
+  GPIO3_1_Handler,                          /* 121 */      /* There are 4 pins in total          */
+  GPIO3_2_Handler,                          /* 122 */
+  GPIO3_3_Handler,                          /* 123 */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined (IOTKit_CM23_VHT)
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/system_IOTKit_CM23.c
+++ b/Layer/Target/CM23_VHT_GCC/RTE/Device/IOTKit_CM23_VHT/system_IOTKit_CM23.c
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * @file     system_IOTKit_CM23.c
+ * @brief    CMSIS Device System Source File for IOTKit_CM23 Device
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (IOTKit_CM23) || defined (IOTKit_CM23_VHT)
+  #include "IOTKit_CM23.h"
+#else
+  #error device not specified!
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+  #include "partition_IOTKit_CM23.h"
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+//  uint32_t blk_cfg, blk_max, blk_size, blk_cnt;
+#endif
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/* start IOT Green configuration ------------------------- */
+
+  /* configure MPC --------------- */
+
+  /* configure unsecure code area MPSSSRAM1 (0x00200000 - 0x003FFFFF) */
+//  blk_max = IOTKIT_MPCSSRAM1->BLK_MAX;   /* = 0x1     */
+//  blk_cfg = IOTKIT_MPCSSRAM1->BLK_CFG;   /* = 0xC     */
+//  blk_size = 1UL << (blk_cfg + 5U);      /* = 0x20000 */
+//  blk_cnt  = 0x200000U / blk_size;       /* = 0x10    */
+
+  IOTKIT_MPCSSRAM1->CTRL    &= ~(1UL << 8U);            /* clear auto increment */
+  IOTKIT_MPCSSRAM1->BLK_IDX  = 0;                       /* write LUT index */
+  IOTKIT_MPCSSRAM1->BLK_LUT  = 0xFFFF0000UL;            /* configure blocks */
+
+
+  /* configure unsecure data area MPSSSRAM3 (0x28200000 - 0x283FFFFF) */
+//  blk_max = IOTKIT_MPCSSRAM3->BLK_MAX;   /* = 0x1     */
+//  blk_cfg = IOTKIT_MPCSSRAM3->BLK_CFG;   /* = 0xB     */
+//  blk_size = 1UL << (blk_cfg + 5U);      /* = 0x10000 */
+//  blk_cnt  = 0x200000U / blk_size;       /* = 0x20    */
+
+  IOTKIT_MPCSSRAM3->CTRL &= ~(1UL << 8U);              /* clear auto increment */
+  IOTKIT_MPCSSRAM3->BLK_IDX = 1;                       /* write LUT index */
+  IOTKIT_MPCSSRAM3->BLK_LUT = 0xFFFFFFFFUL;            /* configure blocks */
+
+
+
+  /* enable the Non Secure Callable Configuration for IDAU (NSCCFG register) */
+  IOTKIT_SPC->NSCCFG |= 1U;
+
+
+  /* configure PPC --------------- */
+#if !defined (__USE_SECURE)
+  /* Allow Non-secure access for SCC/FPGAIO registers */
+  IOTKIT_SPC->APBNSPPCEXP[2U] |= ((1UL << 0U) |
+                                  (1UL << 2U)  );
+  /* Allow Non-secure access for SPI1/UART0 registers */
+  IOTKIT_SPC->APBNSPPCEXP[1U] |= ((1UL << 1U) |
+                                  (1UL << 5U)  );
+#endif
+
+/* end IOT Green configuration --------------------------- */
+
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM23_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM23_VHT_GCC/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2 IOT-Kit:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM23_VHT_GCC/vht_config.txt
+++ b/Layer/Target/CM23_VHT_GCC/vht_config.txt
@@ -1,0 +1,27 @@
+## Parameters:
+## instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+##------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+##------------------------------------------------------------------------------
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+cpu0.BE=0                                             # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.INITVTOR=0                                       # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset
+cpu0.INITVTORNS=0                                     # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored
+cpu0.SAU=4                                            # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU)
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+cpu0.SYST=2                                           # (int   , init-time) default = '0x2'    : Include SysTick timer functionality (0=Absent, 1=Secure only, 2=Secure and NS)
+cpu0.VTOR=1                                           # (bool  , init-time) default = '1'      : Include Vector Table Offset Register
+cpu0.semihosting-enable=0                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+fvp_mps2.platform_type=1                              # (int   , init-time) default = '0x0'    : 0:Original MPS2 ; 1:IoT Kit (cut-down SSE-200) ; 2:Full SSE-200; 3:SVOS
+idau.NUM_IDAU_REGION=0                                # (int   , init-time) default = '0x12'   : 
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM33_FP_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM33_FP_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   NONSEC_WATCHDOG_RESET_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       0
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   NONSEC_WATCHDOG_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       1
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/RTE_Device.h
+++ b/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/ac6_arm.sct
+++ b/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/ac6_arm.sct
@@ -1,0 +1,119 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m33 -xc -mcmse
+; command above MUST be in first line (no comment above!)
+
+;Note: Add '-mcmse' to first line if your software model is "Secure Mode".
+;      #! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m33 -xc -mcmse
+
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x10000000
+#define __ROM_SIZE      0x00200000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x38000000
+#define __RAM_SIZE      0x00200000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000400
+#define __HEAP_SIZE     0x00000C00
+
+/*--------------------- CMSE Venner Configuration ---------------------------
+; <h> CMSE Venner Configuration
+;   <o0>  CMSE Venner Size (in Bytes) <0x0-0xFFFFFFFF:32>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __CMSEVENEER_SIZE    0x200
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE - __STACKSEAL_SIZE) /* starts at end of RAM - 8 byte stack seal */
+#define __HEAP_BASE    (AlignExpr(+0, 8))                           /* starts after RW_RAM section, 8 byte aligned */
+
+/* ----------------------------------------------------------------------------
+  Stack seal size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __STACKSEAL_SIZE   ( 8 )
+#else
+#define __STACKSEAL_SIZE   ( 0 )
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Region base & size definition
+ *----------------------------------------------------------------------------*/
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define __CV_BASE          ( __ROM_BASE + __ROM_SIZE - __CMSEVENEER_SIZE )
+#define __CV_SIZE          ( __CMSEVENEER_SIZE )
+#else
+#define __CV_SIZE          ( 0 )
+#endif
+
+#define __RO_BASE          ( __ROM_BASE )
+#define __RO_SIZE          ( __ROM_SIZE - __CV_SIZE )
+
+#define __RW_BASE          ( __RAM_BASE )
+#define __RW_SIZE          ( __RAM_SIZE - __STACK_SIZE - __HEAP_SIZE )
+
+
+/*----------------------------------------------------------------------------
+  Scatter Region definition
+ *----------------------------------------------------------------------------*/
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_RAM __RW_BASE __RW_SIZE  {                     ; RW data
+   .ANY (+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  STACKSEAL +0 EMPTY __STACKSEAL_SIZE {             ; Reserve empty region for stack seal immediately after stack
+  }
+#endif
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+LR_CMSE_VENEER __CV_BASE ALIGN 32 __CV_SIZE  {      ; own load/execution region for CMSE Venners
+  ER_CMSE_VENEER __CV_BASE __CV_SIZE  {
+   *(Veneer$$CMSE)
+  }
+}
+#endif

--- a/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/partition_IOTKit_CM33.h
+++ b/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/partition_IOTKit_CM33.h
@@ -1,0 +1,637 @@
+/******************************************************************************
+ * @file     partition_IOTKit_CM33.h
+ * @brief    CMSIS-Core Initial Setup for Secure / Non-Secure Zones for IOTKit_CM33
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#ifndef PARTITION_IOTKit_CM33_H
+#define PARTITION_IOTKit_CM33_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          0
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x10000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x101FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x28200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x283FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x403FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  0
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point Unit
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    0
+
+/*
+// Interrupts 0..31
+//   <o.0>  Non-Secure Watchdog Reset Request      <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Non-Secure Watchdog interrupt          <0=> Secure state <1=> Non-Secure state
+//   <o.2>  S32K Timer interrupt                   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Timer 0 interrupt                      <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Timer 1 interrupt                      <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Dual Timer interrupt                   <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    0
+
+/*
+// Interrupts 32..63
+//   <o.0>  UART 0 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.1>  UART 0 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.2>  UART 1 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.3>  UART 1 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.4>  UART 2 teceive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.5>  UART 2 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.6>  UART 3 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.7>  UART 3 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.8>  UART 4 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.9>  UART 4 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.10> UART 0 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.11> UART 1 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.12> UART 2 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.13> UART 3 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.14> UART 4 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.15> UART 0, 1, 2, 3, 4 overflow interrupt  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Ethernet interrupt                     <0=> Secure state <1=> Non-Secure state
+//   <o.17> Audio I2S interrupt                    <0=> Secure state <1=> Non-Secure state
+//   <o.18> Touch Screen interrupt                 <0=> Secure state <1=> Non-Secure state
+//   <o.19> SPI 0 (SPI Header) interrupt           <0=> Secure state <1=> Non-Secure state
+//   <o.20> SPI 1 (CLCD) interrupt                 <0=> Secure state <1=> Non-Secure state
+//   <o.21> SPI 2 (Shield ADC) interrupt           <0=> Secure state <1=> Non-Secure state
+//   <o.22> SPI 3 (Shield 0 SPI) interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.23> SPI 4 (Shield 1 SPI) interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.24> DMA 0 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.25> DMA 0 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.26> DMA 0 combined interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.27> DMA 1 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.28> DMA 1 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.29> DMA 1 combined interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.30> DMA 2 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.31> DMA 2 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  DMA 2 combined interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.1>  DMA 3 error interrupt            <0=> Secure state <1=> Non-Secure state
+//   <o.2>  DMA 3 terminal count interrupt   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  DMA 3 combined interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.4>  GPIO 0 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.5>  GPIO 1 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.6>  GPIO 2 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.7>  GPIO 3 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.8>  GPIO 0 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.9>  GPIO 0 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.10> GPIO 0 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.11> GPIO 0 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.12> GPIO 0 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.13> GPIO 0 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.14> GPIO 0 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.15> GPIO 0 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+//   <o.16> GPIO 0 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.17> GPIO 0 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.18> GPIO 0 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.19> GPIO 0 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.20> GPIO 0 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.21> GPIO 0 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.22> GPIO 0 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.23> GPIO 0 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.24> GPIO 1 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.25> GPIO 1 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.26> GPIO 1 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.27> GPIO 1 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.28> GPIO 1 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.29> GPIO 1 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.30> GPIO 1 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.31> GPIO 1 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  GPIO 1 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.1>  GPIO 1 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.2>  GPIO 1 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.3>  GPIO 1 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.4>  GPIO 1 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.5>  GPIO 1 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.6>  GPIO 1 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.7>  GPIO 1 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.8>  GPIO 2 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.9>  GPIO 2 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.10> GPIO 2 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.11> GPIO 2 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.12> GPIO 2 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.13> GPIO 2 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.14> GPIO 2 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.15> GPIO 2 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+//   <o.16> GPIO 2 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.17> GPIO 2 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.18> GPIO 2 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.19> GPIO 2 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.20> GPIO 2 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.21> GPIO 2 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.22> GPIO 2 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.23> GPIO 2 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.24> GPIO 3 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.25> GPIO 3 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.26> GPIO 3 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.27> GPIO 3 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (__FPU_USED) && (__FPU_USED == 1U) && \
+      defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP10_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_IOTKit_CM33_H */

--- a/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/startup_IOTKit_CM33.c
+++ b/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/startup_IOTKit_CM33.c
@@ -1,0 +1,513 @@
+/******************************************************************************
+ * @file     startup_IOTKit_CM33.c
+ * @brief    CMSIS Startup File for IOTKit_CM33 Device
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (IOTKit_CM33)    || defined (IOTKit_CM33_VHT)
+  #include "IOTKit_CM33.h"
+#elif defined (IOTKit_CM33_FP) || defined (IOTKit_CM33_FP_VHT)
+  #include "IOTKit_CM33_FP.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler               (void) __attribute__ ((weak));
+void MemManage_Handler               (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler             (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Core IoT Interrupts */
+void NONSEC_WATCHDOG_RESET_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void NONSEC_WATCHDOG_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void S32K_TIMER_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler               (void) __attribute__ ((weak, alias("Default_Handler")));
+void MPC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void PPC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void MSC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void BRIDGE_ERROR_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* External Interrupts */
+void UART0RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UARTOVF_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void TSC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI0_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI1_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI2_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI3_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI4_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* VSI Interrupts */
+#if defined (IOTKit_CM33_VHT) || defined (IOTKit_CM33_FP_VHT)
+void ARM_VSI0_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Core IoT Interrupts */
+  NONSEC_WATCHDOG_RESET_Handler,            /*   0 Non-Secure Watchdog Reset Handler */
+  NONSEC_WATCHDOG_Handler,                  /*   1 Non-Secure Watchdog Handler */
+  S32K_TIMER_Handler,                       /*   2 S32K Timer Handler */
+  TIMER0_Handler,                           /*   3 TIMER 0 Handler */
+  TIMER1_Handler,                           /*   4 TIMER 1 Handler */
+  DUALTIMER_Handler,                        /*   5 Dual Timer Handler */
+  0,                                        /*   6 Reserved */
+  0,                                        /*   7 Reserved */
+  0,                                        /*   8 Reserved */
+  MPC_Handler,                              /*   9 MPC Combined (Secure) Handler */
+  PPC_Handler,                              /*  10 PPC Combined (Secure) Handler */
+  MSC_Handler,                              /*  11 MSC Combined (Secure) Handler */
+  BRIDGE_ERROR_Handler,                     /*  12 Bridge Error Combined (Secure) Handler */
+  0,                                        /*  13 Reserved */
+  0,                                        /*  14 Reserved */
+  0,                                        /*  15 Reserved */
+  0,                                        /*  16 Reserved */
+  0,                                        /*  17 Reserved */
+  0,                                        /*  18 Reserved */
+  0,                                        /*  19 Reserved */
+  0,                                        /*  20 Reserved */
+  0,                                        /*  21 Reserved */
+  0,                                        /*  22 Reserved */
+  0,                                        /*  23 Reserved */
+  0,                                        /*  24 Reserved */
+  0,                                        /*  25 Reserved */
+  0,                                        /*  26 Reserved */
+  0,                                        /*  27 Reserved */
+  0,                                        /*  28 Reserved */
+  0,                                        /*  29 Reserved */
+  0,                                        /*  30 Reserved */
+  0,                                        /*  31 Reserved */
+
+  /* External Interrupts */
+  UART0RX_Handler,                          /*  32 UART 0 RX Handler */
+  UART0TX_Handler,                          /*  33 UART 0 TX Handler */
+  UART1RX_Handler,                          /*  34 UART 1 RX Handler */
+  UART1TX_Handler,                          /*  35 UART 1 TX Handler */
+  UART2RX_Handler,                          /*  36 UART 2 RX Handler */
+  UART2TX_Handler,                          /*  37 UART 2 TX Handler */
+  UART3RX_Handler,                          /*  38 UART 2 RX Handler */
+  UART3TX_Handler,                          /*  39 UART 2 TX Handler */
+  UART4RX_Handler,                          /*  40 UART 2 RX Handler */
+  UART4TX_Handler,                          /*  41 UART 2 TX Handler */
+  UART0_Handler,                            /*  42 UART 0 combined Handler */
+  UART1_Handler,                            /*  43 UART 1 combined Handler */
+  UART2_Handler,                            /*  44 UART 2 combined Handler */
+  UART3_Handler,                            /*  45 UART 3 combined Handler */
+  UART4_Handler,                            /*  46 UART 4 combined Handler */
+  UARTOVF_Handler,                          /*  47 UART 0,1,2,3,4 Overflow Handler */
+  ETHERNET_Handler ,                        /*  48 Ethernet Handler */
+  I2S_Handler,                              /*  49 I2S Handler */
+  TSC_Handler,                              /*  50 Touch Screen Handler */
+  SPI0_Handler,                             /*  51 SPI 0 Handler */
+  SPI1_Handler,                             /*  52 SPI 1 Handler */
+  SPI2_Handler,                             /*  53 SPI 2 Handler */
+  SPI3_Handler,                             /*  54 SPI 3 Handler */
+  SPI4_Handler,                             /*  55 SPI 4 Handler */
+  DMA0_ERROR_Handler,                       /*  56 DMA 0 Error Handler */
+  DMA0_TC_Handler,                          /*  57 DMA 0 Terminal Count Handler */
+  DMA0_Handler,                             /*  58 DMA 0 Combined Handler */
+  DMA1_ERROR_Handler,                       /*  59 DMA 1 Error Handler */
+  DMA1_TC_Handler,                          /*  60 DMA 1 Terminal Count Handler */
+  DMA1_Handler,                             /*  61 DMA 1 Combined Handler */
+  DMA2_ERROR_Handler,                       /*  62 DMA 2 Error Handler */
+  DMA2_TC_Handler,                          /*  63 DMA 2 Terminal Count Handler */
+  DMA2_Handler,                             /*  64 DMA 2 Combined Handler */
+  DMA3_ERROR_Handler,                       /*  65 DMA 3 Error Handler */
+  DMA3_TC_Handler,                          /*  66 DMA 3 Terminal Count Handler */
+  DMA3_Handler,                             /*  67 DMA 3 Combined Handler */
+  GPIO0_Handler,                            /*  68 GPIO 0 Combined Handler */
+  GPIO1_Handler,                            /*  69 GPIO 1 Combined Handler */
+  GPIO2_Handler,                            /*  70 GPIO 2 Combined Handler */
+  GPIO3_Handler,                            /*  71 GPIO 3 Combined Handler */
+  GPIO0_0_Handler,                          /*  72 */      /* All P0 I/O pins used as irq source */
+  GPIO0_1_Handler,                          /*  73 */      /* There are 16 pins in total         */
+  GPIO0_2_Handler,                          /*  74 */
+  GPIO0_3_Handler,                          /*  75 */
+  GPIO0_4_Handler,                          /*  76 */
+  GPIO0_5_Handler,                          /*  77 */
+  GPIO0_6_Handler,                          /*  78 */
+  GPIO0_7_Handler,                          /*  79 */
+  GPIO0_8_Handler,                          /*  80 */
+  GPIO0_9_Handler,                          /*  81 */
+  GPIO0_10_Handler,                         /*  82 */
+  GPIO0_11_Handler,                         /*  83 */
+  GPIO0_12_Handler,                         /*  84 */
+  GPIO0_13_Handler,                         /*  85 */
+  GPIO0_14_Handler,                         /*  86 */
+  GPIO0_15_Handler,                         /*  87 */
+  GPIO1_0_Handler,                          /*  88 */      /* All P1 I/O pins used as irq source */
+  GPIO1_1_Handler,                          /*  89 */      /* There are 16 pins in total         */
+  GPIO1_2_Handler,                          /*  90 */
+  GPIO1_3_Handler,                          /*  91 */
+  GPIO1_4_Handler,                          /*  92 */
+  GPIO1_5_Handler,                          /*  93 */
+  GPIO1_6_Handler,                          /*  94 */
+  GPIO1_7_Handler,                          /*  95 */
+  GPIO1_8_Handler,                          /*  96 */
+  GPIO1_9_Handler,                          /*  97 */
+  GPIO1_10_Handler,                         /*  98 */
+  GPIO1_11_Handler,                         /*  99 */
+  GPIO1_12_Handler,                         /* 100 */
+  GPIO1_13_Handler,                         /* 101 */
+  GPIO1_14_Handler,                         /* 102 */
+  GPIO1_15_Handler,                         /* 103 */
+  GPIO2_0_Handler,                          /* 104 */      /* All P2 I/O pins used as irq source */
+  GPIO2_1_Handler,                          /* 105 */      /* There are 16 pins in total         */
+  GPIO2_2_Handler,                          /* 106 */
+  GPIO2_3_Handler,                          /* 107 */
+  GPIO2_4_Handler,                          /* 108 */
+  GPIO2_5_Handler,                          /* 109 */
+  GPIO2_6_Handler,                          /* 110 */
+  GPIO2_7_Handler,                          /* 111 */
+  GPIO2_8_Handler,                          /* 112 */
+  GPIO2_9_Handler,                          /* 113 */
+  GPIO2_10_Handler,                         /* 114 */
+  GPIO2_11_Handler,                         /* 115 */
+  GPIO2_12_Handler,                         /* 116 */
+  GPIO2_13_Handler,                         /* 117 */
+  GPIO2_14_Handler,                         /* 118 */
+  GPIO2_15_Handler,                         /* 119 */
+  GPIO3_0_Handler,                          /* 120 */      /* All P3 I/O pins used as irq source */
+  GPIO3_1_Handler,                          /* 121 */      /* There are 4 pins in total          */
+  GPIO3_2_Handler,                          /* 122 */
+  GPIO3_3_Handler,                          /* 123 */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined (IOTKit_CM33_VHT) || defined (IOTKit_CM33_FP_VHT)
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/system_IOTKit_CM33.c
+++ b/Layer/Target/CM33_FP_VHT_AC6/RTE/Device/IOTKit_CM33_FP_VHT/system_IOTKit_CM33.c
@@ -1,0 +1,149 @@
+/******************************************************************************
+ * @file     system_IOTKit_CM33.c
+ * @brief    CMSIS System Source File for IOTKit_CM33 Device
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (IOTKit_CM33)    || defined (IOTKit_CM33_VHT)
+  #include "IOTKit_CM33.h"
+#elif defined (IOTKit_CM33_FP) || defined (IOTKit_CM33_FP_VHT)
+  #include "IOTKit_CM33_FP.h"
+#else
+  #error device not specified!
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+  #include "partition_IOTKit_CM33.h"
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+//  uint32_t blk_cfg, blk_max, blk_size, blk_cnt;
+#endif
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/* start IOT Green configuration ------------------------- */
+
+  /* Enable BusFault, UsageFault, MemManageFault and SecureFault to ease diagnostic */
+  SCB->SHCSR |= (SCB_SHCSR_USGFAULTENA_Msk  |
+                 SCB_SHCSR_BUSFAULTENA_Msk  |
+                 SCB_SHCSR_MEMFAULTENA_Msk  |
+                 SCB_SHCSR_SECUREFAULTENA_Msk);
+
+  /* BFSR register setting to enable precise errors */
+  SCB->CFSR |= SCB_CFSR_PRECISERR_Msk;
+
+
+  /* configure MPC --------------- */
+
+  /* configure unsecure code area MPSSSRAM1 (0x00200000 - 0x003FFFFF) */
+//  blk_max = IOTKIT_MPCSSRAM1->BLK_MAX;   /* = 0x1     */
+//  blk_cfg = IOTKIT_MPCSSRAM1->BLK_CFG;   /* = 0xC     */
+//  blk_size = 1UL << (blk_cfg + 5U);      /* = 0x20000 */
+//  blk_cnt  = 0x200000U / blk_size;       /* = 0x10    */
+
+  IOTKIT_MPCSSRAM1->CTRL    &= ~(1UL << 8U);            /* clear auto increment */
+  IOTKIT_MPCSSRAM1->BLK_IDX  = 0;                       /* write LUT index */
+  IOTKIT_MPCSSRAM1->BLK_LUT  = 0xFFFF0000UL;            /* configure blocks */
+
+
+  /* configure unsecure data area MPSSSRAM3 (0x28200000 - 0x283FFFFF) */
+//  blk_max = IOTKIT_MPCSSRAM3->BLK_MAX;   /* = 0x1     */
+//  blk_cfg = IOTKIT_MPCSSRAM3->BLK_CFG;   /* = 0xB     */
+//  blk_size = 1UL << (blk_cfg + 5U);      /* = 0x10000 */
+//  blk_cnt  = 0x200000U / blk_size;       /* = 0x20    */
+
+  IOTKIT_MPCSSRAM3->CTRL &= ~(1UL << 8U);              /* clear auto increment */
+  IOTKIT_MPCSSRAM3->BLK_IDX = 1;                       /* write LUT index */
+  IOTKIT_MPCSSRAM3->BLK_LUT = 0xFFFFFFFFUL;            /* configure blocks */
+
+
+
+  /* enable the Non Secure Callable Configuration for IDAU (NSCCFG register) */
+  IOTKIT_SPC->NSCCFG |= 1U;
+
+
+  /* configure PPC --------------- */
+#if !defined (__USE_SECURE)
+  /* Allow Non-secure access for SCC/FPGAIO registers */
+  IOTKIT_SPC->APBNSPPCEXP[2U] |= ((1UL << 0U) |
+                                  (1UL << 2U)  );
+  /* Allow Non-secure access for SPI1/UART0 registers */
+  IOTKIT_SPC->APBNSPPCEXP[1U] |= ((1UL << 1U) |
+                                  (1UL << 5U)  );
+#endif
+
+/* end IOT Green configuration --------------------------- */
+
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM33_FP_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM33_FP_VHT_AC6/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2 IOT-Kit:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM33_FP_VHT_AC6/vht_config.txt
+++ b/Layer/Target/CM33_FP_VHT_AC6/vht_config.txt
@@ -1,0 +1,33 @@
+## Parameters:
+## instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+##------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+##------------------------------------------------------------------------------
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.DSP=1                                            # (bool  , init-time) default = '1'      : Set whether the model has the DSP extension
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.INITNSVTOR=0                                     # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset
+cpu0.INITSVTOR=0                                      # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x8'    : Number of SAU regions (0 => no SAU)
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+cpu0.semihosting-enable=0                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+fvp_mps2.platform_type=1                              # (int   , init-time) default = '0x0'    : 0:Original MPS2 ; 1:IoT Kit (cut-down SSE-200) ; 2:Full SSE-200; 3:SVOS
+idau.NUM_IDAU_REGION=0                                # (int   , init-time) default = '0x12'   : 
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM33_FP_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM33_FP_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   NONSEC_WATCHDOG_RESET_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       0
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   NONSEC_WATCHDOG_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       1
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/RTE_Device.h
+++ b/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/gcc_arm.ld
+++ b/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/gcc_arm.ld
@@ -1,0 +1,299 @@
+/******************************************************************************
+ * @file     gcc_arm.ld
+ * @brief    GNU Linker Script for Cortex-M based device
+ ******************************************************************************/
+
+/*
+; -------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__ROM_BASE = 0x10000000;
+__ROM_SIZE = 0x00200000;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ -----------------------------------------------------------------------------*/
+__RAM_BASE = 0x38000000;
+__RAM_SIZE = 0x00200000;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00000400;
+__HEAP_SIZE  = 0x00000C00;
+
+/*
+; -------------------- <<< end of configuration section >>> -------------------
+ */
+
+/* ARMv8-M stack sealing:
+   to use ARMv8-M stack sealing set __STACKSEAL_SIZE to 8 otherwise keep 0
+ */
+__STACKSEAL_SIZE = 0;
+
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __StackSeal      (only if ARMv8-M stack sealing is used)
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  /*
+   * SG veneers:
+   * All SG veneers are placed in the special output section .gnu.sgstubs. Its start address
+   * must be set, either with the command line option ‘--section-start’ or in a linker script,
+   * to indicate where to place these veneers in memory.
+   */
+/*
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > FLASH
+*/
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__) / 4)
+    /* Add each additional bss section here */
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /**
+   * Location counter can end up 2byte aligned with narrow Thumb code but
+   * __etext is assumed by startup code to be the LMA of a section in RAM
+   * which must be 4byte aligned
+   */
+  __etext = ALIGN (4);
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  __etext2 = ALIGN (4);
+
+  .data2 : AT (__etext2)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (COPY) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE - __STACKSEAL_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+  
+  /* ARMv8-M stack sealing:
+     to use ARMv8-M stack sealing uncomment '.stackseal' section
+   */
+/*
+  .stackseal (ORIGIN(RAM) + LENGTH(RAM) - __STACKSEAL_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackSeal = .;
+    . = . + 8;
+    . = ALIGN(8);
+  } > RAM
+*/
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/partition_IOTKit_CM33.h
+++ b/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/partition_IOTKit_CM33.h
@@ -1,0 +1,637 @@
+/******************************************************************************
+ * @file     partition_IOTKit_CM33.h
+ * @brief    CMSIS-Core Initial Setup for Secure / Non-Secure Zones for IOTKit_CM33
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#ifndef PARTITION_IOTKit_CM33_H
+#define PARTITION_IOTKit_CM33_H
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
+*/
+
+/*
+// <e>Initialize Security Attribution Unit (SAU) CTRL register
+*/
+#define SAU_INIT_CTRL          0
+
+/*
+//   <q> Enable SAU
+//   <i> Value for SAU->CTRL register bit ENABLE
+*/
+#define SAU_INIT_CTRL_ENABLE   1
+
+/*
+//   <o> When SAU is disabled
+//     <0=> All Memory is Secure
+//     <1=> All Memory is Non-Secure
+//   <i> Value for SAU->CTRL register bit ALLNS
+//   <i> When all Memory is Non-Secure (ALLNS is 1), IDAU can override memory map configuration.
+*/
+#define SAU_INIT_CTRL_ALLNS  0
+
+/*
+// </e>
+*/
+
+/*
+// <h>Initialize Security Attribution Unit (SAU) Address Regions
+// <i>SAU configuration specifies regions to be one of:
+// <i> - Secure and Non-Secure Callable
+// <i> - Non-Secure
+// <i>Note: All memory regions not configured by SAU are Secure
+*/
+#define SAU_REGIONS_MAX   8                 /* Max. number of SAU regions */
+
+/*
+//   <e>Initialize SAU Region 0
+//   <i> Setup SAU Region 0 memory attributes
+*/
+#define SAU_INIT_REGION0    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START0     0x10000000      /* start address of SAU region 0 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END0       0x101FFFFF      /* end address of SAU region 0 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC0       1
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 1
+//   <i> Setup SAU Region 1 memory attributes
+*/
+#define SAU_INIT_REGION1    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START1     0x00200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END1       0x003FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC1       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 2
+//   <i> Setup SAU Region 2 memory attributes
+*/
+#define SAU_INIT_REGION2    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START2     0x28200000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END2       0x283FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC2       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 3
+//   <i> Setup SAU Region 3 memory attributes
+*/
+#define SAU_INIT_REGION3    1
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START3     0x40000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END3       0x403FFFFF
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC3       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 4
+//   <i> Setup SAU Region 4 memory attributes
+*/
+#define SAU_INIT_REGION4    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START4     0x00000000      /* start address of SAU region 4 */
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END4       0x00000000      /* end address of SAU region 4 */
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC4       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 5
+//   <i> Setup SAU Region 5 memory attributes
+*/
+#define SAU_INIT_REGION5    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START5     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END5       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC5       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 6
+//   <i> Setup SAU Region 6 memory attributes
+*/
+#define SAU_INIT_REGION6    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START6     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END6       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC6       0
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize SAU Region 7
+//   <i> Setup SAU Region 7 memory attributes
+*/
+#define SAU_INIT_REGION7    0
+
+/*
+//     <o>Start Address <0-0xFFFFFFE0>
+*/
+#define SAU_INIT_START7     0x00000000
+
+/*
+//     <o>End Address <0x1F-0xFFFFFFFF>
+*/
+#define SAU_INIT_END7       0x00000000
+
+/*
+//     <o>Region is
+//         <0=>Non-Secure
+//         <1=>Secure, Non-Secure Callable
+*/
+#define SAU_INIT_NSC7       0
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+/*
+// <e>Setup behaviour of Sleep and Exception Handling
+*/
+#define SCB_CSR_AIRCR_INIT  1
+
+/*
+//   <o> Deep Sleep can be enabled by
+//     <0=>Secure and Non-Secure state
+//     <1=>Secure state only
+//   <i> Value for SCB->CSR register bit DEEPSLEEPS
+*/
+#define SCB_CSR_DEEPSLEEPS_VAL  1
+
+/*
+//   <o>System reset request accessible from
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for SCB->AIRCR register bit SYSRESETREQS
+*/
+#define SCB_AIRCR_SYSRESETREQS_VAL  0
+
+/*
+//   <o>Priority of Non-Secure exceptions is
+//     <0=> Not altered
+//     <1=> Lowered to 0x80-0xFF
+//   <i> Value for SCB->AIRCR register bit PRIS
+*/
+#define SCB_AIRCR_PRIS_VAL      1
+
+/*
+//   <o>BusFault, HardFault, and NMI target
+//     <0=> Secure state
+//     <1=> Non-Secure state
+//   <i> Value for SCB->AIRCR register bit BFHFNMINS
+*/
+#define SCB_AIRCR_BFHFNMINS_VAL 0
+
+/*
+// </e>
+*/
+
+/*
+// <e>Setup behaviour of Floating Point Unit
+*/
+#define TZ_FPU_NS_USAGE 1
+
+/*
+// <o>Floating Point Unit usage
+//     <0=> Secure state only
+//     <3=> Secure and Non-Secure state
+//   <i> Value for SCB->NSACR register bits CP10, CP11
+*/
+#define SCB_NSACR_CP10_11_VAL       3
+
+/*
+// <o>Treat floating-point registers as Secure
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit TS
+*/
+#define FPU_FPCCR_TS_VAL            0
+
+/*
+// <o>Clear on return (CLRONRET) accessibility
+//     <0=> Secure and Non-Secure state
+//     <1=> Secure state only
+//   <i> Value for FPU->FPCCR register bit CLRONRETS
+*/
+#define FPU_FPCCR_CLRONRETS_VAL     0
+
+/*
+// <o>Clear floating-point caller saved registers on exception return
+//     <0=> Disabled
+//     <1=> Enabled
+//   <i> Value for FPU->FPCCR register bit CLRONRET
+*/
+#define FPU_FPCCR_CLRONRET_VAL      1
+
+/*
+// </e>
+*/
+
+/*
+// <h>Setup Interrupt Target
+*/
+
+/*
+//   <e>Initialize ITNS 0 (Interrupts 0..31)
+*/
+#define NVIC_INIT_ITNS0    0
+
+/*
+// Interrupts 0..31
+//   <o.0>  Non-Secure Watchdog Reset Request      <0=> Secure state <1=> Non-Secure state
+//   <o.1>  Non-Secure Watchdog interrupt          <0=> Secure state <1=> Non-Secure state
+//   <o.2>  S32K Timer interrupt                   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  Timer 0 interrupt                      <0=> Secure state <1=> Non-Secure state
+//   <o.4>  Timer 1 interrupt                      <0=> Secure state <1=> Non-Secure state
+//   <o.5>  Dual Timer interrupt                   <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS0_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 1 (Interrupts 32..63)
+*/
+#define NVIC_INIT_ITNS1    0
+
+/*
+// Interrupts 32..63
+//   <o.0>  UART 0 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.1>  UART 0 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.2>  UART 1 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.3>  UART 1 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.4>  UART 2 teceive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.5>  UART 2 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.6>  UART 3 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.7>  UART 3 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.8>  UART 4 receive interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.9>  UART 4 transmit interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.10> UART 0 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.11> UART 1 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.12> UART 2 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.13> UART 3 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.14> UART 4 combined interrupt              <0=> Secure state <1=> Non-Secure state
+//   <o.15> UART 0, 1, 2, 3, 4 overflow interrupt  <0=> Secure state <1=> Non-Secure state
+//   <o.16> Ethernet interrupt                     <0=> Secure state <1=> Non-Secure state
+//   <o.17> Audio I2S interrupt                    <0=> Secure state <1=> Non-Secure state
+//   <o.18> Touch Screen interrupt                 <0=> Secure state <1=> Non-Secure state
+//   <o.19> SPI 0 (SPI Header) interrupt           <0=> Secure state <1=> Non-Secure state
+//   <o.20> SPI 1 (CLCD) interrupt                 <0=> Secure state <1=> Non-Secure state
+//   <o.21> SPI 2 (Shield ADC) interrupt           <0=> Secure state <1=> Non-Secure state
+//   <o.22> SPI 3 (Shield 0 SPI) interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.23> SPI 4 (Shield 1 SPI) interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.24> DMA 0 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.25> DMA 0 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.26> DMA 0 combined interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.27> DMA 1 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.28> DMA 1 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.29> DMA 1 combined interrupt               <0=> Secure state <1=> Non-Secure state
+//   <o.30> DMA 2 error interrupt                  <0=> Secure state <1=> Non-Secure state
+//   <o.31> DMA 2 terminal count interrupt         <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS1_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 2 (Interrupts 64..95)
+*/
+#define NVIC_INIT_ITNS2    0
+
+/*
+// Interrupts 64..95
+//   <o.0>  DMA 2 combined interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.1>  DMA 3 error interrupt            <0=> Secure state <1=> Non-Secure state
+//   <o.2>  DMA 3 terminal count interrupt   <0=> Secure state <1=> Non-Secure state
+//   <o.3>  DMA 3 combined interrupt         <0=> Secure state <1=> Non-Secure state
+//   <o.4>  GPIO 0 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.5>  GPIO 1 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.6>  GPIO 2 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.7>  GPIO 3 combined interrupt        <0=> Secure state <1=> Non-Secure state
+//   <o.8>  GPIO 0 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.9>  GPIO 0 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.10> GPIO 0 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.11> GPIO 0 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.12> GPIO 0 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.13> GPIO 0 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.14> GPIO 0 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.15> GPIO 0 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+//   <o.16> GPIO 0 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.17> GPIO 0 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.18> GPIO 0 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.19> GPIO 0 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.20> GPIO 0 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.21> GPIO 0 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.22> GPIO 0 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.23> GPIO 0 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.24> GPIO 1 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.25> GPIO 1 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.26> GPIO 1 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.27> GPIO 1 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.28> GPIO 1 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.29> GPIO 1 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.30> GPIO 1 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.31> GPIO 1 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS2_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+//   <e>Initialize ITNS 3 (Interrupts 96..127)
+*/
+#define NVIC_INIT_ITNS3    0
+
+/*
+// Interrupts 96..127
+//   <o.0>  GPIO 1 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.1>  GPIO 1 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.2>  GPIO 1 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.3>  GPIO 1 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.4>  GPIO 1 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.5>  GPIO 1 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.6>  GPIO 1 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.7>  GPIO 1 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.8>  GPIO 2 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.9>  GPIO 2 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.10> GPIO 2 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.11> GPIO 2 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+//   <o.12> GPIO 2 individual interrupt ( 4) <0=> Secure state <1=> Non-Secure state
+//   <o.13> GPIO 2 individual interrupt ( 5) <0=> Secure state <1=> Non-Secure state
+//   <o.14> GPIO 2 individual interrupt ( 6) <0=> Secure state <1=> Non-Secure state
+//   <o.15> GPIO 2 individual interrupt ( 7) <0=> Secure state <1=> Non-Secure state
+//   <o.16> GPIO 2 individual interrupt ( 8) <0=> Secure state <1=> Non-Secure state
+//   <o.17> GPIO 2 individual interrupt ( 9) <0=> Secure state <1=> Non-Secure state
+//   <o.18> GPIO 2 individual interrupt (10) <0=> Secure state <1=> Non-Secure state
+//   <o.19> GPIO 2 individual interrupt (11) <0=> Secure state <1=> Non-Secure state
+//   <o.20> GPIO 2 individual interrupt (12) <0=> Secure state <1=> Non-Secure state
+//   <o.21> GPIO 2 individual interrupt (13) <0=> Secure state <1=> Non-Secure state
+//   <o.22> GPIO 2 individual interrupt (14) <0=> Secure state <1=> Non-Secure state
+//   <o.23> GPIO 2 individual interrupt (15) <0=> Secure state <1=> Non-Secure state
+//   <o.24> GPIO 3 individual interrupt ( 0) <0=> Secure state <1=> Non-Secure state
+//   <o.25> GPIO 3 individual interrupt ( 1) <0=> Secure state <1=> Non-Secure state
+//   <o.26> GPIO 3 individual interrupt ( 2) <0=> Secure state <1=> Non-Secure state
+//   <o.27> GPIO 3 individual interrupt ( 3) <0=> Secure state <1=> Non-Secure state
+*/
+#define NVIC_INIT_ITNS3_VAL      0x00000000
+
+/*
+//   </e>
+*/
+
+/*
+// </h>
+*/
+
+
+
+/*
+    max 128 SAU regions.
+    SAU regions are defined in partition.h
+ */
+
+#define SAU_INIT_REGION(n) \
+    SAU->RNR  =  (n                                     & SAU_RNR_REGION_Msk); \
+    SAU->RBAR =  (SAU_INIT_START##n                     & SAU_RBAR_BADDR_Msk); \
+    SAU->RLAR =  (SAU_INIT_END##n                       & SAU_RLAR_LADDR_Msk) | \
+                ((SAU_INIT_NSC##n << SAU_RLAR_NSC_Pos)  & SAU_RLAR_NSC_Msk)   | 1U
+
+/**
+  \brief   Setup a SAU Region
+  \details Writes the region information contained in SAU_Region to the
+           registers SAU_RNR, SAU_RBAR, and SAU_RLAR
+ */
+__STATIC_INLINE void TZ_SAU_Setup (void)
+{
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+
+  #if defined (SAU_INIT_REGION0) && (SAU_INIT_REGION0 == 1U)
+    SAU_INIT_REGION(0);
+  #endif
+
+  #if defined (SAU_INIT_REGION1) && (SAU_INIT_REGION1 == 1U)
+    SAU_INIT_REGION(1);
+  #endif
+
+  #if defined (SAU_INIT_REGION2) && (SAU_INIT_REGION2 == 1U)
+    SAU_INIT_REGION(2);
+  #endif
+
+  #if defined (SAU_INIT_REGION3) && (SAU_INIT_REGION3 == 1U)
+    SAU_INIT_REGION(3);
+  #endif
+
+  #if defined (SAU_INIT_REGION4) && (SAU_INIT_REGION4 == 1U)
+    SAU_INIT_REGION(4);
+  #endif
+
+  #if defined (SAU_INIT_REGION5) && (SAU_INIT_REGION5 == 1U)
+    SAU_INIT_REGION(5);
+  #endif
+
+  #if defined (SAU_INIT_REGION6) && (SAU_INIT_REGION6 == 1U)
+    SAU_INIT_REGION(6);
+  #endif
+
+  #if defined (SAU_INIT_REGION7) && (SAU_INIT_REGION7 == 1U)
+    SAU_INIT_REGION(7);
+  #endif
+
+  /* repeat this for all possible SAU regions */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+
+  #if defined (SAU_INIT_CTRL) && (SAU_INIT_CTRL == 1U)
+    SAU->CTRL = ((SAU_INIT_CTRL_ENABLE << SAU_CTRL_ENABLE_Pos) & SAU_CTRL_ENABLE_Msk) |
+                ((SAU_INIT_CTRL_ALLNS  << SAU_CTRL_ALLNS_Pos)  & SAU_CTRL_ALLNS_Msk)   ;
+  #endif
+
+  #if defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U)
+    SCB->SCR   = (SCB->SCR   & ~(SCB_SCR_SLEEPDEEPS_Msk    )) |
+                   ((SCB_CSR_DEEPSLEEPS_VAL     << SCB_SCR_SLEEPDEEPS_Pos)     & SCB_SCR_SLEEPDEEPS_Msk);
+
+    SCB->AIRCR = (SCB->AIRCR & ~(SCB_AIRCR_VECTKEY_Msk   | SCB_AIRCR_SYSRESETREQS_Msk |
+                                 SCB_AIRCR_BFHFNMINS_Msk | SCB_AIRCR_PRIS_Msk          ))                    |
+                   ((0x05FAU                    << SCB_AIRCR_VECTKEY_Pos)      & SCB_AIRCR_VECTKEY_Msk)      |
+                   ((SCB_AIRCR_SYSRESETREQS_VAL << SCB_AIRCR_SYSRESETREQS_Pos) & SCB_AIRCR_SYSRESETREQS_Msk) |
+                   ((SCB_AIRCR_PRIS_VAL         << SCB_AIRCR_PRIS_Pos)         & SCB_AIRCR_PRIS_Msk)         |
+                   ((SCB_AIRCR_BFHFNMINS_VAL    << SCB_AIRCR_BFHFNMINS_Pos)    & SCB_AIRCR_BFHFNMINS_Msk);
+  #endif /* defined (SCB_CSR_AIRCR_INIT) && (SCB_CSR_AIRCR_INIT == 1U) */
+
+  #if defined (__FPU_USED) && (__FPU_USED == 1U) && \
+      defined (TZ_FPU_NS_USAGE) && (TZ_FPU_NS_USAGE == 1U)
+
+    SCB->NSACR = (SCB->NSACR & ~(SCB_NSACR_CP10_Msk | SCB_NSACR_CP10_Msk)) |
+                   ((SCB_NSACR_CP10_11_VAL << SCB_NSACR_CP10_Pos) & (SCB_NSACR_CP10_Msk | SCB_NSACR_CP11_Msk));
+
+    FPU->FPCCR = (FPU->FPCCR & ~(FPU_FPCCR_TS_Msk | FPU_FPCCR_CLRONRETS_Msk | FPU_FPCCR_CLRONRET_Msk)) |
+                   ((FPU_FPCCR_TS_VAL        << FPU_FPCCR_TS_Pos       ) & FPU_FPCCR_TS_Msk       ) |
+                   ((FPU_FPCCR_CLRONRETS_VAL << FPU_FPCCR_CLRONRETS_Pos) & FPU_FPCCR_CLRONRETS_Msk) |
+                   ((FPU_FPCCR_CLRONRET_VAL  << FPU_FPCCR_CLRONRET_Pos ) & FPU_FPCCR_CLRONRET_Msk );
+  #endif
+
+  #if defined (NVIC_INIT_ITNS0) && (NVIC_INIT_ITNS0 == 1U)
+    NVIC->ITNS[0] = NVIC_INIT_ITNS0_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS1) && (NVIC_INIT_ITNS1 == 1U)
+    NVIC->ITNS[1] = NVIC_INIT_ITNS1_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS2) && (NVIC_INIT_ITNS2 == 1U)
+    NVIC->ITNS[2] = NVIC_INIT_ITNS2_VAL;
+  #endif
+
+  #if defined (NVIC_INIT_ITNS3) && (NVIC_INIT_ITNS3 == 1U)
+    NVIC->ITNS[3] = NVIC_INIT_ITNS3_VAL;
+  #endif
+
+  /* repeat this for all possible ITNS elements */
+
+}
+
+#endif  /* PARTITION_IOTKit_CM33_H */

--- a/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/startup_IOTKit_CM33.c
+++ b/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/startup_IOTKit_CM33.c
@@ -1,0 +1,513 @@
+/******************************************************************************
+ * @file     startup_IOTKit_CM33.c
+ * @brief    CMSIS Startup File for IOTKit_CM33 Device
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (IOTKit_CM33)    || defined (IOTKit_CM33_VHT)
+  #include "IOTKit_CM33.h"
+#elif defined (IOTKit_CM33_FP) || defined (IOTKit_CM33_FP_VHT)
+  #include "IOTKit_CM33_FP.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint32_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler               (void) __attribute__ ((weak));
+void MemManage_Handler               (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void SecureFault_Handler             (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Core IoT Interrupts */
+void NONSEC_WATCHDOG_RESET_Handler   (void) __attribute__ ((weak, alias("Default_Handler")));
+void NONSEC_WATCHDOG_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void S32K_TIMER_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler                  (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler               (void) __attribute__ ((weak, alias("Default_Handler")));
+void MPC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void PPC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void MSC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void BRIDGE_ERROR_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* External Interrupts */
+void UART0RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void UARTOVF_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void TSC_Handler                     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI0_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI1_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI2_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI3_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI4_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA0_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA1_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA2_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_ERROR_Handler              (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_TC_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void DMA3_Handler                    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler                   (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_4_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_5_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_6_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_7_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_8_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_9_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_10_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_11_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_12_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_13_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_14_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_15_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_0_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_1_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_2_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_3_Handler                 (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* VSI Interrupts */
+#if defined (IOTKit_CM33_VHT) || defined (IOTKit_CM33_FP_VHT)
+void ARM_VSI0_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler                (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  SecureFault_Handler,                      /*  -9 Secure Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Core IoT Interrupts */
+  NONSEC_WATCHDOG_RESET_Handler,            /*   0 Non-Secure Watchdog Reset Handler */
+  NONSEC_WATCHDOG_Handler,                  /*   1 Non-Secure Watchdog Handler */
+  S32K_TIMER_Handler,                       /*   2 S32K Timer Handler */
+  TIMER0_Handler,                           /*   3 TIMER 0 Handler */
+  TIMER1_Handler,                           /*   4 TIMER 1 Handler */
+  DUALTIMER_Handler,                        /*   5 Dual Timer Handler */
+  0,                                        /*   6 Reserved */
+  0,                                        /*   7 Reserved */
+  0,                                        /*   8 Reserved */
+  MPC_Handler,                              /*   9 MPC Combined (Secure) Handler */
+  PPC_Handler,                              /*  10 PPC Combined (Secure) Handler */
+  MSC_Handler,                              /*  11 MSC Combined (Secure) Handler */
+  BRIDGE_ERROR_Handler,                     /*  12 Bridge Error Combined (Secure) Handler */
+  0,                                        /*  13 Reserved */
+  0,                                        /*  14 Reserved */
+  0,                                        /*  15 Reserved */
+  0,                                        /*  16 Reserved */
+  0,                                        /*  17 Reserved */
+  0,                                        /*  18 Reserved */
+  0,                                        /*  19 Reserved */
+  0,                                        /*  20 Reserved */
+  0,                                        /*  21 Reserved */
+  0,                                        /*  22 Reserved */
+  0,                                        /*  23 Reserved */
+  0,                                        /*  24 Reserved */
+  0,                                        /*  25 Reserved */
+  0,                                        /*  26 Reserved */
+  0,                                        /*  27 Reserved */
+  0,                                        /*  28 Reserved */
+  0,                                        /*  29 Reserved */
+  0,                                        /*  30 Reserved */
+  0,                                        /*  31 Reserved */
+
+  /* External Interrupts */
+  UART0RX_Handler,                          /*  32 UART 0 RX Handler */
+  UART0TX_Handler,                          /*  33 UART 0 TX Handler */
+  UART1RX_Handler,                          /*  34 UART 1 RX Handler */
+  UART1TX_Handler,                          /*  35 UART 1 TX Handler */
+  UART2RX_Handler,                          /*  36 UART 2 RX Handler */
+  UART2TX_Handler,                          /*  37 UART 2 TX Handler */
+  UART3RX_Handler,                          /*  38 UART 2 RX Handler */
+  UART3TX_Handler,                          /*  39 UART 2 TX Handler */
+  UART4RX_Handler,                          /*  40 UART 2 RX Handler */
+  UART4TX_Handler,                          /*  41 UART 2 TX Handler */
+  UART0_Handler,                            /*  42 UART 0 combined Handler */
+  UART1_Handler,                            /*  43 UART 1 combined Handler */
+  UART2_Handler,                            /*  44 UART 2 combined Handler */
+  UART3_Handler,                            /*  45 UART 3 combined Handler */
+  UART4_Handler,                            /*  46 UART 4 combined Handler */
+  UARTOVF_Handler,                          /*  47 UART 0,1,2,3,4 Overflow Handler */
+  ETHERNET_Handler ,                        /*  48 Ethernet Handler */
+  I2S_Handler,                              /*  49 I2S Handler */
+  TSC_Handler,                              /*  50 Touch Screen Handler */
+  SPI0_Handler,                             /*  51 SPI 0 Handler */
+  SPI1_Handler,                             /*  52 SPI 1 Handler */
+  SPI2_Handler,                             /*  53 SPI 2 Handler */
+  SPI3_Handler,                             /*  54 SPI 3 Handler */
+  SPI4_Handler,                             /*  55 SPI 4 Handler */
+  DMA0_ERROR_Handler,                       /*  56 DMA 0 Error Handler */
+  DMA0_TC_Handler,                          /*  57 DMA 0 Terminal Count Handler */
+  DMA0_Handler,                             /*  58 DMA 0 Combined Handler */
+  DMA1_ERROR_Handler,                       /*  59 DMA 1 Error Handler */
+  DMA1_TC_Handler,                          /*  60 DMA 1 Terminal Count Handler */
+  DMA1_Handler,                             /*  61 DMA 1 Combined Handler */
+  DMA2_ERROR_Handler,                       /*  62 DMA 2 Error Handler */
+  DMA2_TC_Handler,                          /*  63 DMA 2 Terminal Count Handler */
+  DMA2_Handler,                             /*  64 DMA 2 Combined Handler */
+  DMA3_ERROR_Handler,                       /*  65 DMA 3 Error Handler */
+  DMA3_TC_Handler,                          /*  66 DMA 3 Terminal Count Handler */
+  DMA3_Handler,                             /*  67 DMA 3 Combined Handler */
+  GPIO0_Handler,                            /*  68 GPIO 0 Combined Handler */
+  GPIO1_Handler,                            /*  69 GPIO 1 Combined Handler */
+  GPIO2_Handler,                            /*  70 GPIO 2 Combined Handler */
+  GPIO3_Handler,                            /*  71 GPIO 3 Combined Handler */
+  GPIO0_0_Handler,                          /*  72 */      /* All P0 I/O pins used as irq source */
+  GPIO0_1_Handler,                          /*  73 */      /* There are 16 pins in total         */
+  GPIO0_2_Handler,                          /*  74 */
+  GPIO0_3_Handler,                          /*  75 */
+  GPIO0_4_Handler,                          /*  76 */
+  GPIO0_5_Handler,                          /*  77 */
+  GPIO0_6_Handler,                          /*  78 */
+  GPIO0_7_Handler,                          /*  79 */
+  GPIO0_8_Handler,                          /*  80 */
+  GPIO0_9_Handler,                          /*  81 */
+  GPIO0_10_Handler,                         /*  82 */
+  GPIO0_11_Handler,                         /*  83 */
+  GPIO0_12_Handler,                         /*  84 */
+  GPIO0_13_Handler,                         /*  85 */
+  GPIO0_14_Handler,                         /*  86 */
+  GPIO0_15_Handler,                         /*  87 */
+  GPIO1_0_Handler,                          /*  88 */      /* All P1 I/O pins used as irq source */
+  GPIO1_1_Handler,                          /*  89 */      /* There are 16 pins in total         */
+  GPIO1_2_Handler,                          /*  90 */
+  GPIO1_3_Handler,                          /*  91 */
+  GPIO1_4_Handler,                          /*  92 */
+  GPIO1_5_Handler,                          /*  93 */
+  GPIO1_6_Handler,                          /*  94 */
+  GPIO1_7_Handler,                          /*  95 */
+  GPIO1_8_Handler,                          /*  96 */
+  GPIO1_9_Handler,                          /*  97 */
+  GPIO1_10_Handler,                         /*  98 */
+  GPIO1_11_Handler,                         /*  99 */
+  GPIO1_12_Handler,                         /* 100 */
+  GPIO1_13_Handler,                         /* 101 */
+  GPIO1_14_Handler,                         /* 102 */
+  GPIO1_15_Handler,                         /* 103 */
+  GPIO2_0_Handler,                          /* 104 */      /* All P2 I/O pins used as irq source */
+  GPIO2_1_Handler,                          /* 105 */      /* There are 16 pins in total         */
+  GPIO2_2_Handler,                          /* 106 */
+  GPIO2_3_Handler,                          /* 107 */
+  GPIO2_4_Handler,                          /* 108 */
+  GPIO2_5_Handler,                          /* 109 */
+  GPIO2_6_Handler,                          /* 110 */
+  GPIO2_7_Handler,                          /* 111 */
+  GPIO2_8_Handler,                          /* 112 */
+  GPIO2_9_Handler,                          /* 113 */
+  GPIO2_10_Handler,                         /* 114 */
+  GPIO2_11_Handler,                         /* 115 */
+  GPIO2_12_Handler,                         /* 116 */
+  GPIO2_13_Handler,                         /* 117 */
+  GPIO2_14_Handler,                         /* 118 */
+  GPIO2_15_Handler,                         /* 119 */
+  GPIO3_0_Handler,                          /* 120 */      /* All P3 I/O pins used as irq source */
+  GPIO3_1_Handler,                          /* 121 */      /* There are 4 pins in total          */
+  GPIO3_2_Handler,                          /* 122 */
+  GPIO3_3_Handler,                          /* 123 */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined (IOTKit_CM33_VHT) || defined (IOTKit_CM33_FP_VHT)
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  __set_PSP((uint32_t)(&__INITIAL_SP));
+
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+  __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/system_IOTKit_CM33.c
+++ b/Layer/Target/CM33_FP_VHT_GCC/RTE/Device/IOTKit_CM33_FP_VHT/system_IOTKit_CM33.c
@@ -1,0 +1,149 @@
+/******************************************************************************
+ * @file     system_IOTKit_CM33.c
+ * @brief    CMSIS System Source File for IOTKit_CM33 Device
+ ******************************************************************************/
+/* Copyright (c) 2015 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (IOTKit_CM33)    || defined (IOTKit_CM33_VHT)
+  #include "IOTKit_CM33.h"
+#elif defined (IOTKit_CM33_FP) || defined (IOTKit_CM33_FP_VHT)
+  #include "IOTKit_CM33_FP.h"
+#else
+  #error device not specified!
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+  #include "partition_IOTKit_CM33.h"
+#endif
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+//  uint32_t blk_cfg, blk_max, blk_size, blk_cnt;
+#endif
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/* start IOT Green configuration ------------------------- */
+
+  /* Enable BusFault, UsageFault, MemManageFault and SecureFault to ease diagnostic */
+  SCB->SHCSR |= (SCB_SHCSR_USGFAULTENA_Msk  |
+                 SCB_SHCSR_BUSFAULTENA_Msk  |
+                 SCB_SHCSR_MEMFAULTENA_Msk  |
+                 SCB_SHCSR_SECUREFAULTENA_Msk);
+
+  /* BFSR register setting to enable precise errors */
+  SCB->CFSR |= SCB_CFSR_PRECISERR_Msk;
+
+
+  /* configure MPC --------------- */
+
+  /* configure unsecure code area MPSSSRAM1 (0x00200000 - 0x003FFFFF) */
+//  blk_max = IOTKIT_MPCSSRAM1->BLK_MAX;   /* = 0x1     */
+//  blk_cfg = IOTKIT_MPCSSRAM1->BLK_CFG;   /* = 0xC     */
+//  blk_size = 1UL << (blk_cfg + 5U);      /* = 0x20000 */
+//  blk_cnt  = 0x200000U / blk_size;       /* = 0x10    */
+
+  IOTKIT_MPCSSRAM1->CTRL    &= ~(1UL << 8U);            /* clear auto increment */
+  IOTKIT_MPCSSRAM1->BLK_IDX  = 0;                       /* write LUT index */
+  IOTKIT_MPCSSRAM1->BLK_LUT  = 0xFFFF0000UL;            /* configure blocks */
+
+
+  /* configure unsecure data area MPSSSRAM3 (0x28200000 - 0x283FFFFF) */
+//  blk_max = IOTKIT_MPCSSRAM3->BLK_MAX;   /* = 0x1     */
+//  blk_cfg = IOTKIT_MPCSSRAM3->BLK_CFG;   /* = 0xB     */
+//  blk_size = 1UL << (blk_cfg + 5U);      /* = 0x10000 */
+//  blk_cnt  = 0x200000U / blk_size;       /* = 0x20    */
+
+  IOTKIT_MPCSSRAM3->CTRL &= ~(1UL << 8U);              /* clear auto increment */
+  IOTKIT_MPCSSRAM3->BLK_IDX = 1;                       /* write LUT index */
+  IOTKIT_MPCSSRAM3->BLK_LUT = 0xFFFFFFFFUL;            /* configure blocks */
+
+
+
+  /* enable the Non Secure Callable Configuration for IDAU (NSCCFG register) */
+  IOTKIT_SPC->NSCCFG |= 1U;
+
+
+  /* configure PPC --------------- */
+#if !defined (__USE_SECURE)
+  /* Allow Non-secure access for SCC/FPGAIO registers */
+  IOTKIT_SPC->APBNSPPCEXP[2U] |= ((1UL << 0U) |
+                                  (1UL << 2U)  );
+  /* Allow Non-secure access for SPI1/UART0 registers */
+  IOTKIT_SPC->APBNSPPCEXP[1U] |= ((1UL << 1U) |
+                                  (1UL << 5U)  );
+#endif
+
+/* end IOT Green configuration --------------------------- */
+
+  TZ_SAU_Setup();
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM33_FP_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM33_FP_VHT_GCC/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2 IOT-Kit:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM33_FP_VHT_GCC/vht_config.txt
+++ b/Layer/Target/CM33_FP_VHT_GCC/vht_config.txt
@@ -1,0 +1,33 @@
+## Parameters:
+## instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+##------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+##------------------------------------------------------------------------------
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode
+cpu0.CPIF=1                                           # (bool  , init-time) default = '1'      : Specifies whether the external coprocessor interface is included
+cpu0.DSP=1                                            # (bool  , init-time) default = '1'      : Set whether the model has the DSP extension
+cpu0.FPU=1                                            # (bool  , init-time) default = '1'      : Set whether the model has VFP support
+cpu0.INITNSVTOR=0                                     # (int   , init-time) default = '0x0'    : Non-Secure vector-table offset at reset
+cpu0.INITSVTOR=0                                      # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset
+cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority
+cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
+cpu0.LOCK_NS_MPU=0                                    # (bool  , init-time) default = '0'      : Lock down of Non-Secure MPU registers write
+cpu0.LOCK_SAU=0                                       # (bool  , init-time) default = '0'      : Lock down of SAU registers write
+cpu0.LOCK_S_MPU=0                                     # (bool  , init-time) default = '0'      : Lock down of Secure MPU registers write
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored
+cpu0.SAU=0x8                                          # (int   , init-time) default = '0x8'    : Number of SAU regions (0 => no SAU)
+cpu0.SAU_CTRL.ALLNS=0                                 # (bool  , init-time) default = '0'      : At reset, the SAU treats entire memory space as NS when the SAU is disabled if this is set
+cpu0.SAU_CTRL.ENABLE=0                                # (bool  , init-time) default = '0'      : Enable SAU at reset
+cpu0.SECEXT=1                                         # (bool  , init-time) default = '1'      : Whether the ARMv8-M Security Extensions are included
+cpu0.semihosting-enable=0                             # (bool  , init-time) default = '1'      : Enable semihosting SVC traps. Applications that do not use semihosting must set this parameter to false.
+fvp_mps2.DISABLE_GATING=1                             # (bool  , init-time) default = '0'      : Disable Memory gating logic
+fvp_mps2.platform_type=1                              # (int   , init-time) default = '0x0'    : 0:Original MPS2 ; 1:IoT Kit (cut-down SSE-200) ; 2:Full SSE-200; 3:SVOS
+idau.NUM_IDAU_REGION=0                                # (int   , init-time) default = '0x12'   : 
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM3_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM3_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM3_VHT_AC6/RTE/Device/CMSDK_CM3_VHT/RTE_Device.h
+++ b/Layer/Target/CM3_VHT_AC6/RTE/Device/CMSDK_CM3_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM3_VHT_AC6/RTE/Device/CMSDK_CM3_VHT/ac6_arm.sct
+++ b/Layer/Target/CM3_VHT_AC6/RTE/Device/CMSDK_CM3_VHT/ac6_arm.sct
@@ -1,0 +1,76 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m3 -xc
+; command above MUST be in first line (no comment above!)
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE)    /* starts at end of RAM */
+#define __HEAP_BASE    (AlignExpr(+0, 8))           /* starts after RW_RAM section, 8 byte aligned */
+
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+#define __RO_BASE       __ROM_BASE
+#define __RO_SIZE       __ROM_SIZE
+
+#define __RW_BASE       __RAM_BASE
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE)
+
+
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_RAM __RW_BASE __RW_SIZE  {                     ; RW data
+   .ANY (+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+}

--- a/Layer/Target/CM3_VHT_AC6/RTE/Device/CMSDK_CM3_VHT/startup_CMSDK_CM3.c
+++ b/Layer/Target/CM3_VHT_AC6/RTE/Device/CMSDK_CM3_VHT/startup_CMSDK_CM3.c
@@ -1,0 +1,421 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM3.c
+ * @brief    CMSIS Startup File for CMSDK_M3 Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (CMSDK_CM3) || defined (CMSDK_CM3_VHT)
+  #include "CMSDK_CM3.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM3_VHT
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler,                          /*  31 GPIO 0 individual interrupt ( 7) */
+  0,                                        /*  32 Reserved */
+  0,                                        /*  33 Reserved */
+  0,                                        /*  34 Reserved */
+  0,                                        /*  35 Reserved */
+  0,                                        /*  36 Reserved */
+  0,                                        /*  37 Reserved */
+  0,                                        /*  38 Reserved */
+  0,                                        /*  39 Reserved */
+  0,                                        /*  40 Reserved */
+  0,                                        /*  41 Reserved */
+  0,                                        /*  42 Reserved */
+  0,                                        /*  43 Reserved */
+  0,                                        /*  44 Reserved */
+  0,                                        /*  45 Reserved */
+  0,                                        /*  46 Reserved */
+  0,                                        /*  47 Reserved */
+  0,                                        /*  48 Reserved */
+  0,                                        /*  49 Reserved */
+  0,                                        /*  50 Reserved */
+  0,                                        /*  51 Reserved */
+  0,                                        /*  52 Reserved */
+  0,                                        /*  53 Reserved */
+  0,                                        /*  54 Reserved */
+  0,                                        /*  55 Reserved */
+  0,                                        /*  56 Reserved */
+  0,                                        /*  57 Reserved */
+  0,                                        /*  58 Reserved */
+  0,                                        /*  59 Reserved */
+  0,                                        /*  60 Reserved */
+  0,                                        /*  61 Reserved */
+  0,                                        /*  62 Reserved */
+  0,                                        /*  63 Reserved */
+  0,                                        /*  64 Reserved */
+  0,                                        /*  65 Reserved */
+  0,                                        /*  66 Reserved */
+  0,                                        /*  67 Reserved */
+  0,                                        /*  68 Reserved */
+  0,                                        /*  69 Reserved */
+  0,                                        /*  70 Reserved */
+  0,                                        /*  71 Reserved */
+  0,                                        /*  72 Reserved */
+  0,                                        /*  73 Reserved */
+  0,                                        /*  74 Reserved */
+  0,                                        /*  75 Reserved */
+  0,                                        /*  76 Reserved */
+  0,                                        /*  77 Reserved */
+  0,                                        /*  78 Reserved */
+  0,                                        /*  79 Reserved */
+  0,                                        /*  80 Reserved */
+  0,                                        /*  81 Reserved */
+  0,                                        /*  82 Reserved */
+  0,                                        /*  83 Reserved */
+  0,                                        /*  84 Reserved */
+  0,                                        /*  85 Reserved */
+  0,                                        /*  86 Reserved */
+  0,                                        /*  87 Reserved */
+  0,                                        /*  88 Reserved */
+  0,                                        /*  89 Reserved */
+  0,                                        /*  90 Reserved */
+  0,                                        /*  91 Reserved */
+  0,                                        /*  92 Reserved */
+  0,                                        /*  93 Reserved */
+  0,                                        /*  94 Reserved */
+  0,                                        /*  95 Reserved */
+  0,                                        /*  96 Reserved */
+  0,                                        /*  97 Reserved */
+  0,                                        /*  98 Reserved */
+  0,                                        /*  99 Reserved */
+  0,                                        /* 100 Reserved */
+  0,                                        /* 101 Reserved */
+  0,                                        /* 102 Reserved */
+  0,                                        /* 103 Reserved */
+  0,                                        /* 104 Reserved */
+  0,                                        /* 105 Reserved */
+  0,                                        /* 106 Reserved */
+  0,                                        /* 107 Reserved */
+  0,                                        /* 108 Reserved */
+  0,                                        /* 109 Reserved */
+  0,                                        /* 110 Reserved */
+  0,                                        /* 111 Reserved */
+  0,                                        /* 112 Reserved */
+  0,                                        /* 113 Reserved */
+  0,                                        /* 114 Reserved */
+  0,                                        /* 115 Reserved */
+  0,                                        /* 116 Reserved */
+  0,                                        /* 117 Reserved */
+  0,                                        /* 118 Reserved */
+  0,                                        /* 119 Reserved */
+  0,                                        /* 120 Reserved */
+  0,                                        /* 121 Reserved */
+  0,                                        /* 122 Reserved */
+  0,                                        /* 123 Reserved */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined CMSDK_CM3_VHT
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM3_VHT_AC6/RTE/Device/CMSDK_CM3_VHT/system_CMSDK_CM3.c
+++ b/Layer/Target/CM3_VHT_AC6/RTE/Device/CMSDK_CM3_VHT/system_CMSDK_CM3.c
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM3.c
+ * @brief    CMSIS System Source File for CMSDK_M3 Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (CMSDK_CM3) || defined (CMSDK_CM3_VHT)
+  #include "CMSDK_CM3.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM3_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM3_VHT_AC6/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM3_VHT_AC6/vht_config.txt
+++ b/Layer/Target/CM3_VHT_AC6/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM3_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM3_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM3_VHT_GCC/RTE/Device/CMSDK_CM3_VHT/RTE_Device.h
+++ b/Layer/Target/CM3_VHT_GCC/RTE/Device/CMSDK_CM3_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM3_VHT_GCC/RTE/Device/CMSDK_CM3_VHT/gcc_arm.ld
+++ b/Layer/Target/CM3_VHT_GCC/RTE/Device/CMSDK_CM3_VHT/gcc_arm.ld
@@ -1,0 +1,279 @@
+/******************************************************************************
+ * @file     gcc_arm.ld
+ * @brief    GNU Linker Script for Cortex-M based device
+ ******************************************************************************/
+
+/*
+; -------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__ROM_BASE = 0x00000000;
+__ROM_SIZE = 0x00040000;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ -----------------------------------------------------------------------------*/
+__RAM_BASE = 0x20000000;
+__RAM_SIZE = 0x00020000;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00000400;
+__HEAP_SIZE  = 0x00000C00;
+
+/*
+; -------------------- <<< end of configuration section >>> -------------------
+ */
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  /*
+   * SG veneers:
+   * All SG veneers are placed in the special output section .gnu.sgstubs. Its start address
+   * must be set, either with the command line option ‘--section-start’ or in a linker script,
+   * to indicate where to place these veneers in memory.
+   */
+/*
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > FLASH
+*/
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__) / 4)
+    /* Add each additional bss section here */
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /**
+   * Location counter can end up 2byte aligned with narrow Thumb code but
+   * __etext is assumed by startup code to be the LMA of a section in RAM
+   * which must be 4byte aligned
+   */
+  __etext = ALIGN (4);
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  __etext2 = ALIGN (4);
+
+  .data2 : AT (__etext2)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (COPY) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/Layer/Target/CM3_VHT_GCC/RTE/Device/CMSDK_CM3_VHT/startup_CMSDK_CM3.c
+++ b/Layer/Target/CM3_VHT_GCC/RTE/Device/CMSDK_CM3_VHT/startup_CMSDK_CM3.c
@@ -1,0 +1,421 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM3.c
+ * @brief    CMSIS Startup File for CMSDK_M3 Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (CMSDK_CM3) || defined (CMSDK_CM3_VHT)
+  #include "CMSDK_CM3.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM3_VHT
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler,                          /*  31 GPIO 0 individual interrupt ( 7) */
+  0,                                        /*  32 Reserved */
+  0,                                        /*  33 Reserved */
+  0,                                        /*  34 Reserved */
+  0,                                        /*  35 Reserved */
+  0,                                        /*  36 Reserved */
+  0,                                        /*  37 Reserved */
+  0,                                        /*  38 Reserved */
+  0,                                        /*  39 Reserved */
+  0,                                        /*  40 Reserved */
+  0,                                        /*  41 Reserved */
+  0,                                        /*  42 Reserved */
+  0,                                        /*  43 Reserved */
+  0,                                        /*  44 Reserved */
+  0,                                        /*  45 Reserved */
+  0,                                        /*  46 Reserved */
+  0,                                        /*  47 Reserved */
+  0,                                        /*  48 Reserved */
+  0,                                        /*  49 Reserved */
+  0,                                        /*  50 Reserved */
+  0,                                        /*  51 Reserved */
+  0,                                        /*  52 Reserved */
+  0,                                        /*  53 Reserved */
+  0,                                        /*  54 Reserved */
+  0,                                        /*  55 Reserved */
+  0,                                        /*  56 Reserved */
+  0,                                        /*  57 Reserved */
+  0,                                        /*  58 Reserved */
+  0,                                        /*  59 Reserved */
+  0,                                        /*  60 Reserved */
+  0,                                        /*  61 Reserved */
+  0,                                        /*  62 Reserved */
+  0,                                        /*  63 Reserved */
+  0,                                        /*  64 Reserved */
+  0,                                        /*  65 Reserved */
+  0,                                        /*  66 Reserved */
+  0,                                        /*  67 Reserved */
+  0,                                        /*  68 Reserved */
+  0,                                        /*  69 Reserved */
+  0,                                        /*  70 Reserved */
+  0,                                        /*  71 Reserved */
+  0,                                        /*  72 Reserved */
+  0,                                        /*  73 Reserved */
+  0,                                        /*  74 Reserved */
+  0,                                        /*  75 Reserved */
+  0,                                        /*  76 Reserved */
+  0,                                        /*  77 Reserved */
+  0,                                        /*  78 Reserved */
+  0,                                        /*  79 Reserved */
+  0,                                        /*  80 Reserved */
+  0,                                        /*  81 Reserved */
+  0,                                        /*  82 Reserved */
+  0,                                        /*  83 Reserved */
+  0,                                        /*  84 Reserved */
+  0,                                        /*  85 Reserved */
+  0,                                        /*  86 Reserved */
+  0,                                        /*  87 Reserved */
+  0,                                        /*  88 Reserved */
+  0,                                        /*  89 Reserved */
+  0,                                        /*  90 Reserved */
+  0,                                        /*  91 Reserved */
+  0,                                        /*  92 Reserved */
+  0,                                        /*  93 Reserved */
+  0,                                        /*  94 Reserved */
+  0,                                        /*  95 Reserved */
+  0,                                        /*  96 Reserved */
+  0,                                        /*  97 Reserved */
+  0,                                        /*  98 Reserved */
+  0,                                        /*  99 Reserved */
+  0,                                        /* 100 Reserved */
+  0,                                        /* 101 Reserved */
+  0,                                        /* 102 Reserved */
+  0,                                        /* 103 Reserved */
+  0,                                        /* 104 Reserved */
+  0,                                        /* 105 Reserved */
+  0,                                        /* 106 Reserved */
+  0,                                        /* 107 Reserved */
+  0,                                        /* 108 Reserved */
+  0,                                        /* 109 Reserved */
+  0,                                        /* 110 Reserved */
+  0,                                        /* 111 Reserved */
+  0,                                        /* 112 Reserved */
+  0,                                        /* 113 Reserved */
+  0,                                        /* 114 Reserved */
+  0,                                        /* 115 Reserved */
+  0,                                        /* 116 Reserved */
+  0,                                        /* 117 Reserved */
+  0,                                        /* 118 Reserved */
+  0,                                        /* 119 Reserved */
+  0,                                        /* 120 Reserved */
+  0,                                        /* 121 Reserved */
+  0,                                        /* 122 Reserved */
+  0,                                        /* 123 Reserved */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined CMSDK_CM3_VHT
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM3_VHT_GCC/RTE/Device/CMSDK_CM3_VHT/system_CMSDK_CM3.c
+++ b/Layer/Target/CM3_VHT_GCC/RTE/Device/CMSDK_CM3_VHT/system_CMSDK_CM3.c
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM3.c
+ * @brief    CMSIS System Source File for CMSDK_M3 Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if defined (CMSDK_CM3) || defined (CMSDK_CM3_VHT)
+  #include "CMSDK_CM3.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM3_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM3_VHT_GCC/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM3_VHT_GCC/vht_config.txt
+++ b/Layer/Target/CM3_VHT_GCC/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM4_FP_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM4_FP_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM4_FP_VHT_AC6/RTE/Device/CMSDK_CM4_FP_VHT/RTE_Device.h
+++ b/Layer/Target/CM4_FP_VHT_AC6/RTE/Device/CMSDK_CM4_FP_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM4_FP_VHT_AC6/RTE/Device/CMSDK_CM4_FP_VHT/ac6_arm.sct
+++ b/Layer/Target/CM4_FP_VHT_AC6/RTE/Device/CMSDK_CM4_FP_VHT/ac6_arm.sct
@@ -1,0 +1,76 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m4 -xc
+; command above MUST be in first line (no comment above!)
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE)    /* starts at end of RAM */
+#define __HEAP_BASE    (AlignExpr(+0, 8))           /* starts after RW_RAM section, 8 byte aligned */
+
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+#define __RO_BASE       __ROM_BASE
+#define __RO_SIZE       __ROM_SIZE
+
+#define __RW_BASE       __RAM_BASE
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE)
+
+
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_RAM __RW_BASE __RW_SIZE  {                     ; RW data
+   .ANY (+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+}

--- a/Layer/Target/CM4_FP_VHT_AC6/RTE/Device/CMSDK_CM4_FP_VHT/startup_CMSDK_CM4.c
+++ b/Layer/Target/CM4_FP_VHT_AC6/RTE/Device/CMSDK_CM4_FP_VHT/startup_CMSDK_CM4.c
@@ -1,0 +1,423 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM4.c
+ * @brief    CMSIS Startup File for CMSDK_M4 Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM4)    || defined (CMSDK_CM4_VHT)
+  #include "CMSDK_CM4.h"
+#elif defined (CMSDK_CM4_FP) || defined (CMSDK_CM4_FP_VHT)
+  #include "CMSDK_CM4_FP.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM4_VHT || defined CMSDK_CM4_FP_VHT
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler,                          /*  31 GPIO 0 individual interrupt ( 7) */
+  0,                                        /*  32 Reserved */
+  0,                                        /*  33 Reserved */
+  0,                                        /*  34 Reserved */
+  0,                                        /*  35 Reserved */
+  0,                                        /*  36 Reserved */
+  0,                                        /*  37 Reserved */
+  0,                                        /*  38 Reserved */
+  0,                                        /*  39 Reserved */
+  0,                                        /*  40 Reserved */
+  0,                                        /*  41 Reserved */
+  0,                                        /*  42 Reserved */
+  0,                                        /*  43 Reserved */
+  0,                                        /*  44 Reserved */
+  0,                                        /*  45 Reserved */
+  0,                                        /*  46 Reserved */
+  0,                                        /*  47 Reserved */
+  0,                                        /*  48 Reserved */
+  0,                                        /*  49 Reserved */
+  0,                                        /*  50 Reserved */
+  0,                                        /*  51 Reserved */
+  0,                                        /*  52 Reserved */
+  0,                                        /*  53 Reserved */
+  0,                                        /*  54 Reserved */
+  0,                                        /*  55 Reserved */
+  0,                                        /*  56 Reserved */
+  0,                                        /*  57 Reserved */
+  0,                                        /*  58 Reserved */
+  0,                                        /*  59 Reserved */
+  0,                                        /*  60 Reserved */
+  0,                                        /*  61 Reserved */
+  0,                                        /*  62 Reserved */
+  0,                                        /*  63 Reserved */
+  0,                                        /*  64 Reserved */
+  0,                                        /*  65 Reserved */
+  0,                                        /*  66 Reserved */
+  0,                                        /*  67 Reserved */
+  0,                                        /*  68 Reserved */
+  0,                                        /*  69 Reserved */
+  0,                                        /*  70 Reserved */
+  0,                                        /*  71 Reserved */
+  0,                                        /*  72 Reserved */
+  0,                                        /*  73 Reserved */
+  0,                                        /*  74 Reserved */
+  0,                                        /*  75 Reserved */
+  0,                                        /*  76 Reserved */
+  0,                                        /*  77 Reserved */
+  0,                                        /*  78 Reserved */
+  0,                                        /*  79 Reserved */
+  0,                                        /*  80 Reserved */
+  0,                                        /*  81 Reserved */
+  0,                                        /*  82 Reserved */
+  0,                                        /*  83 Reserved */
+  0,                                        /*  84 Reserved */
+  0,                                        /*  85 Reserved */
+  0,                                        /*  86 Reserved */
+  0,                                        /*  87 Reserved */
+  0,                                        /*  88 Reserved */
+  0,                                        /*  89 Reserved */
+  0,                                        /*  90 Reserved */
+  0,                                        /*  91 Reserved */
+  0,                                        /*  92 Reserved */
+  0,                                        /*  93 Reserved */
+  0,                                        /*  94 Reserved */
+  0,                                        /*  95 Reserved */
+  0,                                        /*  96 Reserved */
+  0,                                        /*  97 Reserved */
+  0,                                        /*  98 Reserved */
+  0,                                        /*  99 Reserved */
+  0,                                        /* 100 Reserved */
+  0,                                        /* 101 Reserved */
+  0,                                        /* 102 Reserved */
+  0,                                        /* 103 Reserved */
+  0,                                        /* 104 Reserved */
+  0,                                        /* 105 Reserved */
+  0,                                        /* 106 Reserved */
+  0,                                        /* 107 Reserved */
+  0,                                        /* 108 Reserved */
+  0,                                        /* 109 Reserved */
+  0,                                        /* 110 Reserved */
+  0,                                        /* 111 Reserved */
+  0,                                        /* 112 Reserved */
+  0,                                        /* 113 Reserved */
+  0,                                        /* 114 Reserved */
+  0,                                        /* 115 Reserved */
+  0,                                        /* 116 Reserved */
+  0,                                        /* 117 Reserved */
+  0,                                        /* 118 Reserved */
+  0,                                        /* 119 Reserved */
+  0,                                        /* 120 Reserved */
+  0,                                        /* 121 Reserved */
+  0,                                        /* 122 Reserved */
+  0,                                        /* 123 Reserved */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined CMSDK_CM4_VHT || defined CMSDK_CM4_FP_VHT
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM4_FP_VHT_AC6/RTE/Device/CMSDK_CM4_FP_VHT/system_CMSDK_CM4.c
+++ b/Layer/Target/CM4_FP_VHT_AC6/RTE/Device/CMSDK_CM4_FP_VHT/system_CMSDK_CM4.c
@@ -1,0 +1,85 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM4.c
+ * @brief    CMSIS System Source File for CMSDK_M4 Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM4)    || defined (CMSDK_CM4_VHT)
+  #include "CMSDK_CM4.h"
+#elif defined (CMSDK_CM4_FP) || defined (CMSDK_CM4_FP_VHT)
+  #include "CMSDK_CM4_FP.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM4_FP_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM4_FP_VHT_AC6/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM4_FP_VHT_AC6/vht_config.txt
+++ b/Layer/Target/CM4_FP_VHT_AC6/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM4_FP_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM4_FP_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM4_FP_VHT_GCC/RTE/Device/CMSDK_CM4_FP_VHT/RTE_Device.h
+++ b/Layer/Target/CM4_FP_VHT_GCC/RTE/Device/CMSDK_CM4_FP_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM4_FP_VHT_GCC/RTE/Device/CMSDK_CM4_FP_VHT/gcc_arm.ld
+++ b/Layer/Target/CM4_FP_VHT_GCC/RTE/Device/CMSDK_CM4_FP_VHT/gcc_arm.ld
@@ -1,0 +1,279 @@
+/******************************************************************************
+ * @file     gcc_arm.ld
+ * @brief    GNU Linker Script for Cortex-M based device
+ ******************************************************************************/
+
+/*
+; -------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__ROM_BASE = 0x00000000;
+__ROM_SIZE = 0x00040000;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ -----------------------------------------------------------------------------*/
+__RAM_BASE = 0x20000000;
+__RAM_SIZE = 0x00020000;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00000400;
+__HEAP_SIZE  = 0x00000C00;
+
+/*
+; -------------------- <<< end of configuration section >>> -------------------
+ */
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  /*
+   * SG veneers:
+   * All SG veneers are placed in the special output section .gnu.sgstubs. Its start address
+   * must be set, either with the command line option ‘--section-start’ or in a linker script,
+   * to indicate where to place these veneers in memory.
+   */
+/*
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > FLASH
+*/
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__) / 4)
+    /* Add each additional bss section here */
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /**
+   * Location counter can end up 2byte aligned with narrow Thumb code but
+   * __etext is assumed by startup code to be the LMA of a section in RAM
+   * which must be 4byte aligned
+   */
+  __etext = ALIGN (4);
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  __etext2 = ALIGN (4);
+
+  .data2 : AT (__etext2)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (COPY) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/Layer/Target/CM4_FP_VHT_GCC/RTE/Device/CMSDK_CM4_FP_VHT/startup_CMSDK_CM4.c
+++ b/Layer/Target/CM4_FP_VHT_GCC/RTE/Device/CMSDK_CM4_FP_VHT/startup_CMSDK_CM4.c
@@ -1,0 +1,423 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM4.c
+ * @brief    CMSIS Startup File for CMSDK_M4 Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM4)    || defined (CMSDK_CM4_VHT)
+  #include "CMSDK_CM4.h"
+#elif defined (CMSDK_CM4_FP) || defined (CMSDK_CM4_FP_VHT)
+  #include "CMSDK_CM4_FP.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM4_VHT || defined CMSDK_CM4_FP_VHT
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler,                          /*  31 GPIO 0 individual interrupt ( 7) */
+  0,                                        /*  32 Reserved */
+  0,                                        /*  33 Reserved */
+  0,                                        /*  34 Reserved */
+  0,                                        /*  35 Reserved */
+  0,                                        /*  36 Reserved */
+  0,                                        /*  37 Reserved */
+  0,                                        /*  38 Reserved */
+  0,                                        /*  39 Reserved */
+  0,                                        /*  40 Reserved */
+  0,                                        /*  41 Reserved */
+  0,                                        /*  42 Reserved */
+  0,                                        /*  43 Reserved */
+  0,                                        /*  44 Reserved */
+  0,                                        /*  45 Reserved */
+  0,                                        /*  46 Reserved */
+  0,                                        /*  47 Reserved */
+  0,                                        /*  48 Reserved */
+  0,                                        /*  49 Reserved */
+  0,                                        /*  50 Reserved */
+  0,                                        /*  51 Reserved */
+  0,                                        /*  52 Reserved */
+  0,                                        /*  53 Reserved */
+  0,                                        /*  54 Reserved */
+  0,                                        /*  55 Reserved */
+  0,                                        /*  56 Reserved */
+  0,                                        /*  57 Reserved */
+  0,                                        /*  58 Reserved */
+  0,                                        /*  59 Reserved */
+  0,                                        /*  60 Reserved */
+  0,                                        /*  61 Reserved */
+  0,                                        /*  62 Reserved */
+  0,                                        /*  63 Reserved */
+  0,                                        /*  64 Reserved */
+  0,                                        /*  65 Reserved */
+  0,                                        /*  66 Reserved */
+  0,                                        /*  67 Reserved */
+  0,                                        /*  68 Reserved */
+  0,                                        /*  69 Reserved */
+  0,                                        /*  70 Reserved */
+  0,                                        /*  71 Reserved */
+  0,                                        /*  72 Reserved */
+  0,                                        /*  73 Reserved */
+  0,                                        /*  74 Reserved */
+  0,                                        /*  75 Reserved */
+  0,                                        /*  76 Reserved */
+  0,                                        /*  77 Reserved */
+  0,                                        /*  78 Reserved */
+  0,                                        /*  79 Reserved */
+  0,                                        /*  80 Reserved */
+  0,                                        /*  81 Reserved */
+  0,                                        /*  82 Reserved */
+  0,                                        /*  83 Reserved */
+  0,                                        /*  84 Reserved */
+  0,                                        /*  85 Reserved */
+  0,                                        /*  86 Reserved */
+  0,                                        /*  87 Reserved */
+  0,                                        /*  88 Reserved */
+  0,                                        /*  89 Reserved */
+  0,                                        /*  90 Reserved */
+  0,                                        /*  91 Reserved */
+  0,                                        /*  92 Reserved */
+  0,                                        /*  93 Reserved */
+  0,                                        /*  94 Reserved */
+  0,                                        /*  95 Reserved */
+  0,                                        /*  96 Reserved */
+  0,                                        /*  97 Reserved */
+  0,                                        /*  98 Reserved */
+  0,                                        /*  99 Reserved */
+  0,                                        /* 100 Reserved */
+  0,                                        /* 101 Reserved */
+  0,                                        /* 102 Reserved */
+  0,                                        /* 103 Reserved */
+  0,                                        /* 104 Reserved */
+  0,                                        /* 105 Reserved */
+  0,                                        /* 106 Reserved */
+  0,                                        /* 107 Reserved */
+  0,                                        /* 108 Reserved */
+  0,                                        /* 109 Reserved */
+  0,                                        /* 110 Reserved */
+  0,                                        /* 111 Reserved */
+  0,                                        /* 112 Reserved */
+  0,                                        /* 113 Reserved */
+  0,                                        /* 114 Reserved */
+  0,                                        /* 115 Reserved */
+  0,                                        /* 116 Reserved */
+  0,                                        /* 117 Reserved */
+  0,                                        /* 118 Reserved */
+  0,                                        /* 119 Reserved */
+  0,                                        /* 120 Reserved */
+  0,                                        /* 121 Reserved */
+  0,                                        /* 122 Reserved */
+  0,                                        /* 123 Reserved */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined CMSDK_CM4_VHT || defined CMSDK_CM4_FP_VHT
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM4_FP_VHT_GCC/RTE/Device/CMSDK_CM4_FP_VHT/system_CMSDK_CM4.c
+++ b/Layer/Target/CM4_FP_VHT_GCC/RTE/Device/CMSDK_CM4_FP_VHT/system_CMSDK_CM4.c
@@ -1,0 +1,85 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM4.c
+ * @brief    CMSIS System Source File for CMSDK_M4 Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM4)    || defined (CMSDK_CM4_VHT)
+  #include "CMSDK_CM4.h"
+#elif defined (CMSDK_CM4_FP) || defined (CMSDK_CM4_FP_VHT)
+  #include "CMSDK_CM4_FP.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM4_FP_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM4_FP_VHT_GCC/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM4_FP_VHT_GCC/vht_config.txt
+++ b/Layer/Target/CM4_FP_VHT_GCC/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM55_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM55_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   NONSEC_WATCHDOG_RESET_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       0
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   NONSEC_WATCHDOG_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       1
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/RTE_Device.h
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/RTE_Device.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019-2022 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::Drivers:USART
+#define   RTE_USART0                     1
+
+// <q> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::Drivers:USART
+#define   RTE_USART1                     1
+
+// <q> MPC (Memory Protection Controller) [Driver_ISRAM0_MPC]
+// <i> Configuration settings for Driver_ISRAM0_MPC in component ::Drivers:MPC
+#define   RTE_ISRAM0_MPC                 1
+
+// <q> MPC (Memory Protection Controller) [Driver_ISRAM1_MPC]
+// <i> Configuration settings for Driver_ISRAM1_MPC in component ::Drivers:MPC
+#define   RTE_ISRAM1_MPC                 1
+
+// <q> MPC (Memory Protection Controller) [Driver_SRAM_MPC]
+// <i> Configuration settings for Driver_SRAM_MPC in component ::Drivers:MPC
+#define   RTE_SRAM_MPC                   1
+
+// <q> MPC (Memory Protection Controller) [Driver_QSPI_MPC]
+// <i> Configuration settings for Driver_QSPI_MPC in component ::Drivers:MPC
+#define   RTE_QSPI_MPC                   1
+
+// <q> PPC (Peripheral Protection Controller) [PPC_SSE300_MAIN0]
+// <i> Configuration settings for Driver_PPC_SSE300_MAIN0 in component ::Drivers:PPC
+#define   RTE_PPC_SSE300_MAIN0             1
+
+// <q> PPC (Peripheral Protection Controller) [PPC_SSE300_MAIN_EXP0]
+// <i> Configuration settings for Driver_PPC_SSE300_MAIN_EXP0 in component ::Drivers:PPC
+#define   RTE_PPC_SSE300_MAIN_EXP0             1
+
+// <q> PPC (Peripheral Protection Controller) [PPC_SSE300_MAIN_EXP1]
+// <i> Configuration settings for Driver_PPC_SSE300_MAIN_EXP1 in component ::Drivers:PPC
+#define   RTE_PPC_SSE300_MAIN_EXP1             1
+
+// <q> PPC (Peripheral Protection Controller) [PPC_SSE300_PERIPH0]
+// <i> Configuration settings for Driver_PPC_SSE300_PERIPH0 in component ::Drivers:PPC
+#define   RTE_PPC_SSE300_PERIPH0             1
+
+// <q> PPC (Peripheral Protection Controller) [PPC_SSE300_PERIPH1]
+// <i> Configuration settings for Driver_PPC_SSE300_PERIPH1 in component ::Drivers:PPC
+#define   RTE_PPC_SSE300_PERIPH1             1
+
+// <q> PPC (Peripheral Protection Controller) [PPC_SSE300_PERIPH_EXP0]
+// <i> Configuration settings for Driver_PPC_SSE300_PERIPH_EXP0 in component ::Drivers:PPC
+#define   RTE_PPC_SSE300_PERIPH_EXP0             1
+
+// <q> PPC (Peripheral Protection Controller) [PPC_SSE300_PERIPH_EXP1]
+// <i> Configuration settings for Driver_PPC_SSE300_PERIPH_EXP1 in component ::Drivers:PPC
+#define   RTE_PPC_SSE300_PERIPH_EXP1             1
+
+// <q> PPC (Peripheral Protection Controller) [PPC_SSE300_PERIPH_EXP2]
+// <i> Configuration settings for Driver_PPC_SSE300_PERIPH_EXP2 in component ::Drivers:PPC
+#define   RTE_PPC_SSE300_PERIPH_EXP2             1
+
+// <q> Flash device emulated by SRAM [Driver_Flash0]
+// <i> Configuration settings for Driver_Flash0 in component ::Drivers:Flash
+#define   RTE_FLASH0                     1
+
+// <q> I2C SBCon [Driver_I2C0]
+// <i> Configuration settings for Driver_I2C0 in component ::Drivers:I2C
+#define   RTE_I2C0                    1
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/cmsis_driver_config.h
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/cmsis_driver_config.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019-2022 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CMSIS_DRIVER_CONFIG_H__
+#define __CMSIS_DRIVER_CONFIG_H__
+
+#include "system_SSE300MPS3.h"
+#include "device_cfg.h"
+#include "device_definition.h"
+#include "platform_base_address.h"
+
+#endif  /* __CMSIS_DRIVER_CONFIG_H__ */

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/device_cfg.h
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/device_cfg.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2020-2022 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DEVICE_CFG_H__
+#define __DEVICE_CFG_H__
+
+/**
+ * \file device_cfg.h
+ * \brief Configuration file native driver re-targeting
+ *
+ * \details This file can be used to add native driver specific macro
+ *          definitions to select which peripherals are available in the build.
+ *
+ * This is a default device configuration file with all peripherals enabled.
+ */
+
+/* Secure only peripheral configuration */
+
+/* ARM MPS3 IO SCC */
+#define MPS3_IO_S
+#define MPS3_IO_DEV                 MPS3_IO_DEV_S
+
+/* I2C_SBCon */
+#define I2C0_SBCON_S
+#define I2C0_SBCON_DEV              I2C0_SBCON_DEV_S
+
+/* I2S */
+#define MPS3_I2S_S
+#define MPS3_I2S_DEV                MPS3_I2S_DEV_S
+
+/* ARM UART Controller PL011 */
+#define UART0_CMSDK_S
+#define UART0_CMSDK_DEV          UART0_CMSDK_DEV_S
+#define UART1_CMSDK_S
+#define UART1_CMSDK_DEV          UART1_CMSDK_DEV_S
+
+#define DEFAULT_UART_BAUDRATE    115200U
+
+/* To be used as CODE and DATA sram */
+#define MPC_ISRAM0_S
+#define MPC_ISRAM0_DEV              MPC_ISRAM0_DEV_S
+
+#define MPC_ISRAM1_S
+#define MPC_ISRAM1_DEV              MPC_ISRAM0_DEV_S
+
+#define MPC_SRAM_S
+#define MPC_SRAM_DEV                MPC_SRAM_DEV_S
+
+#define MPC_QSPI_S
+#define MPC_QSPI_DEV                MPC_QSPI_DEV_S
+
+/** System Counter Armv8-M */
+#define SYSCOUNTER_CNTRL_ARMV8_M_S
+#define SYSCOUNTER_CNTRL_ARMV8_M_DEV    SYSCOUNTER_CNTRL_ARMV8_M_DEV_S
+
+#define SYSCOUNTER_READ_ARMV8_M_S
+#define SYSCOUNTER_READ_ARMV8_M_DEV     SYSCOUNTER_READ_ARMV8_M_DEV_S
+/**
+ * Arbitrary scaling values for test purposes
+ */
+#define SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_INT           1u
+#define SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_FRACT         0u
+#define SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_INT           1u
+#define SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_FRACT         0u
+
+/* System timer */
+#define SYSTIMER0_ARMV8_M_S
+#define SYSTIMER0_ARMV8_M_DEV    SYSTIMER0_ARMV8_M_DEV_S
+#define SYSTIMER1_ARMV8_M_S
+#define SYSTIMER1_ARMV8_M_DEV    SYSTIMER1_ARMV8_M_DEV_S
+#define SYSTIMER2_ARMV8_M_S
+#define SYSTIMER2_ARMV8_M_DEV    SYSTIMER2_ARMV8_M_DEV_S
+#define SYSTIMER3_ARMV8_M_S
+#define SYSTIMER3_ARMV8_M_DEV    SYSTIMER3_ARMV8_M_DEV_S
+
+#define SYSTIMER0_ARMV8M_DEFAULT_FREQ_HZ    (25000000ul)
+#define SYSTIMER1_ARMV8M_DEFAULT_FREQ_HZ    (25000000ul)
+#define SYSTIMER2_ARMV8M_DEFAULT_FREQ_HZ    (25000000ul)
+#define SYSTIMER3_ARMV8M_DEFAULT_FREQ_HZ    (25000000ul)
+
+/* CMSDK GPIO driver structures */
+#define GPIO0_CMSDK_S
+#define GPIO0_CMSDK_DEV GPIO0_CMSDK_DEV_S
+#define GPIO1_CMSDK_S
+#define GPIO1_CMSDK_DEV GPIO1_CMSDK_DEV_S
+#define GPIO2_CMSDK_S
+#define GPIO2_CMSDK_DEV GPIO2_CMSDK_DEV_S
+#define GPIO3_CMSDK_S
+#define GPIO3_CMSDK_DEV GPIO3_CMSDK_DEV_S
+
+/* System Watchdogs */
+#define SYSWDOG_ARMV8_M_S
+#define SYSWDOG_ARMV8_M_DEV SYSWDOG_ARMV8_M_DEV_S
+
+/* ARM MPC SIE 300 driver structures */
+#define MPC_VM0_S
+#define MPC_VM0_DEV MPC_VM0_DEV_S
+#define MPC_VM1_S
+#define MPC_VM1_DEV MPC_VM1_DEV_S
+#define MPC_SSRAM2_S
+#define MPC_SSRAM2_DEV MPC_SSRAM2_DEV_S
+#define MPC_SSRAM3_S
+#define MPC_SSRAM3_DEV MPC_SSRAM3_DEV_S
+
+/* ARM PPC driver structures */
+#define PPC_SSE300_MAIN0_S
+#define PPC_SSE300_MAIN0_DEV PPC_SSE300_MAIN0_DEV_S
+#define PPC_SSE300_MAIN_EXP0_S
+#define PPC_SSE300_MAIN_EXP0_DEV PPC_SSE300_MAIN_EXP0_DEV_S
+#define PPC_SSE300_MAIN_EXP1_S
+#define PPC_SSE300_MAIN_EXP1_DEV PPC_SSE300_MAIN_EXP1_DEV_S
+#define PPC_SSE300_MAIN_EXP2_S
+#define PPC_SSE300_MAIN_EXP2_DEV PPC_SSE300_MAIN_EXP2_DEV_S
+#define PPC_SSE300_MAIN_EXP3_S
+#define PPC_SSE300_MAIN_EXP3_DEV PPC_SSE300_MAIN_EXP3_DEV_S
+#define PPC_SSE300_PERIPH0_S
+#define PPC_SSE300_PERIPH0_DEV PPC_SSE300_PERIPH0_DEV_S
+#define PPC_SSE300_PERIPH1_S
+#define PPC_SSE300_PERIPH1_DEV PPC_SSE300_PERIPH1_DEV_S
+#define PPC_SSE300_PERIPH_EXP0_S
+#define PPC_SSE300_PERIPH_EXP0_DEV PPC_SSE300_PERIPH_EXP0_DEV_S
+#define PPC_SSE300_PERIPH_EXP1_S
+#define PPC_SSE300_PERIPH_EXP1_DEV PPC_SSE300_PERIPH_EXP1_DEV_S
+#define PPC_SSE300_PERIPH_EXP2_S
+#define PPC_SSE300_PERIPH_EXP2_DEV PPC_SSE300_PERIPH_EXP2_DEV_S
+#define PPC_SSE300_PERIPH_EXP3_S
+#define PPC_SSE300_PERIPH_EXP3_DEV PPC_SSE300_PERIPH_EXP3_DEV_S
+
+/* ARM SPI PL022 */
+/* Invalid device stubs are not defined */
+#define DEFAULT_SPI_SPEED_HZ  4000000U /* 4MHz */
+#define SPI1_PL022_S
+#define SPI1_PL022_DEV SPI1_PL022_DEV_S
+
+
+#endif  /* __DEVICE_CFG_H__ */

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/fvp_sse300_mps3_s.sct
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/fvp_sse300_mps3_s.sct
@@ -1,0 +1,78 @@
+#! armclang --target=arm-arm-none-eabi -march=armv8.1-m.main -E -xc
+
+;/*
+; * Copyright (c) 2018-2021 Arm Limited. All rights reserved.
+; *
+; * Licensed under the Apache License, Version 2.0 (the "License");
+; * you may not use this file except in compliance with the License.
+; * You may obtain a copy of the License at
+; *
+; *     http://www.apache.org/licenses/LICENSE-2.0
+; *
+; * Unless required by applicable law or agreed to in writing, software
+; * distributed under the License is distributed on an "AS IS" BASIS,
+; * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; * See the License for the specific language governing permissions and
+; * limitations under the License.
+; *
+; */
+
+#include "region_defs.h"
+
+LR_CODE S_CODE_START {
+    ER_CODE S_CODE_START {
+        *.o (RESET +First)
+        .ANY (+RO)
+    }
+
+    /*
+     * Place the CMSE Veneers (containing the SG instruction) after the code, in
+     * a separate 32 bytes aligned region so that the SAU can programmed to just
+     * set this region as Non-Secure Callable. The maximum size of this
+     * executable region makes it only used the space left over by the ER_CODE
+     * region so that you can rely on code+veneer size combined will not exceed
+     * the S_CODE_SIZE value. We also substract from the available space the
+     * area used to align this section on 32 bytes boundary (for SAU conf).
+     */
+    ER_CODE_CMSE_VENEER +0 ALIGN 32 {
+        *(Veneer$$CMSE)
+    }
+    /*
+     * This dummy region ensures that the next one will be aligned on a 32 bytes
+     * boundary, so that the following region will not be mistakenly configured
+     * as Non-Secure Callable by the SAU.
+     */
+    ER_CODE_CMSE_VENEER_DUMMY +0 ALIGN 32 EMPTY 0 {}
+
+    /* This empty, zero long execution region is here to mark the limit address
+     * of the last execution region that is allocated in SRAM.
+     */
+    CODE_WATERMARK +0 EMPTY 0x0 {
+    }
+    /* Make sure that the sections allocated in the SRAM does not exceed the
+     * size of the SRAM available.
+     */
+    ScatterAssert(ImageLimit(CODE_WATERMARK) <= S_CODE_START + S_CODE_SIZE)
+
+    ER_DATA S_DATA_START {
+        .ANY (+ZI +RW)
+    }
+
+    #if HEAP_SIZE > 0
+    ARM_LIB_HEAP +0 ALIGN 8 EMPTY  HEAP_SIZE  {   ; Reserve empty region for heap
+    }
+    #endif
+
+    ARM_LIB_STACK +0 ALIGN 32 EMPTY STACK_SIZE {   ; Reserve empty region for stack
+    }
+
+    /* This empty, zero long execution region is here to mark the limit address
+     * of the last execution region that is allocated in SRAM.
+     */
+    SRAM_WATERMARK +0 EMPTY 0x0 {
+    }
+    /* Make sure that the sections allocated in the SRAM does not exceed the
+     * size of the SRAM available.
+     */
+    ScatterAssert(ImageLimit(SRAM_WATERMARK) <= S_DATA_START + S_DATA_SIZE)
+}

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/platform_base_address.h
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/platform_base_address.h
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2019-2021 Arm Limited
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \file platform_base_address.h
+ * \brief This file defines all the peripheral base addresses for AN552 MPS3 SSE-300 +
+ *        Ethos-U55 platform.
+ */
+
+#ifndef __PLATFORM_BASE_ADDRESS_H__
+#define __PLATFORM_BASE_ADDRESS_H__
+
+/* ======= Defines peripherals memory map addresses ======= */
+/* Non-secure memory map addresses */
+#define ITCM_BASE_NS                     0x00000000 /* Instruction TCM Non-Secure base address */
+#define SRAM_BASE_NS                     0x01000000 /* CODE SRAM Non-Secure base address */
+#define DTCM0_BASE_NS                    0x20000000 /* Data TCM block 0 Non-Secure base address */
+#define DTCM1_BASE_NS                    0x20020000 /* Data TCM block 1 Non-Secure base address */
+#define DTCM2_BASE_NS                    0x20040000 /* Data TCM block 2 Non-Secure base address */
+#define DTCM3_BASE_NS                    0x20060000 /* Data TCM block 3 Non-Secure base address */
+#define ISRAM0_BASE_NS                   0x21000000 /* Internal SRAM Area Non-Secure base address */
+#define ISRAM1_BASE_NS                   0x21100000 /* Internal SRAM Area Non-Secure base address */
+#define QSPI_SRAM_BASE_NS                0x28000000 /* QSPI SRAM Non-Secure base address */
+/* Non-Secure Subsystem peripheral region */
+#define CPU0_PWRCTRL_BASE_NS             0x40012000 /* CPU 0 Power Control Block Non-Secure base address */
+#define CPU0_IDENTITY_BASE_NS            0x4001F000 /* CPU 0 Identity Block Non-Secure base address */
+#define SSE300_NSACFG_BASE_NS            0x40080000 /* SSE-300 Non-Secure Access Configuration Register Block Non-Secure base address */
+/* Non-Secure MSTEXPPILL Peripheral region */
+#define GPIO0_CMSDK_BASE_NS              0x41100000 /* GPIO 0 Non-Secure base address */
+#define GPIO1_CMSDK_BASE_NS              0x41101000 /* GPIO 1 Non-Secure base address */
+#define GPIO2_CMSDK_BASE_NS              0x41102000 /* GPIO 2 Non-Secure base address */
+#define GPIO3_CMSDK_BASE_NS              0x41103000 /* GPIO 3 Non-Secure base address */
+#define FMC_CMSDK_GPIO_0_BASE_NS         0x41104000 /* FMC CMSDK GPIO 0 Non-Secure base address */
+#define FMC_CMSDK_GPIO_1_BASE_NS         0x41105000 /* FMC CMSDK GPIO 1 Non-Secure base address */
+#define FMC_CMSDK_GPIO_2_BASE_NS         0x41106000 /* FMC CMSDK GPIO 2 Non-Secure base address */
+#define FMC_CMSDK_GPIO_3_BASE_NS         0x41107000 /* FMC CMSDK GPIO 3 Non-Secure base address */
+#define EXTERNAL_MANAGER_0_BASE_NS       0x41200000 /* External manager 0 (Unused) Non-Secure base address */
+#define EXTERNAL_MANAGER_1_BASE_NS       0x41201000 /* External manager 1 (Unused) Non-Secure base address */
+#define EXTERNAL_MANAGER_2_BASE_NS       0x41202000 /* External manager 2 (Unused) Non-Secure base address */
+#define EXTERNAL_MANAGER_3_BASE_NS       0x41203000 /* External manager 3 (Unused) Non-Secure base address */
+#define ETHERNET_BASE_NS                 0x41400000 /* Ethernet Non-Secure base address */
+#define USB_BASE_NS                      0x41500000 /* USB Non-Secure base address */
+#define USER_APB0_BASE_NS                0x41700000 /* User APB 0 Non-Secure base address */
+#define USER_APB1_BASE_NS                0x41701000 /* User APB 1 Non-Secure base address */
+#define USER_APB2_BASE_NS                0x41702000 /* User APB 2 Non-Secure base address */
+#define USER_APB3_BASE_NS                0x41703000 /* User APB 3 Non-Secure base address */
+#define QSPI_CONFIG_BASE_NS              0x41800000 /* QSPI Config Non-Secure base address */
+#define QSPI_WRITE_BASE_NS               0x41801000 /* QSPI Write Non-Secure base address */
+/* Non-Secure Subsystem peripheral region */
+#define SYSTIMER0_ARMV8_M_BASE_NS        0x48000000 /* System Timer 0 Non-Secure base address */
+#define SYSTIMER1_ARMV8_M_BASE_NS        0x48001000 /* System Timer 1 Non-Secure base address */
+#define SYSTIMER2_ARMV8_M_BASE_NS        0x48002000 /* System Timer 2 Non-Secure base address */
+#define SYSTIMER3_ARMV8_M_BASE_NS        0x48003000 /* System Timer 3 Non-Secure base address */
+#define SSE300_SYSINFO_BASE_NS           0x48020000 /* SSE-300 System info Block Non-Secure base address */
+#define SLOWCLK_TIMER_CMSDK_BASE_NS      0x4802F000 /* CMSDK based SLOWCLK Timer Non-Secure base address */
+#define SYSWDOG_ARMV8_M_CNTRL_BASE_NS    0x48040000 /* Non-Secure Watchdog Timer control frame Non-Secure base address */
+#define SYSWDOG_ARMV8_M_REFRESH_BASE_NS  0x48041000 /* Non-Secure Watchdog Timer refresh frame Non-Secure base address */
+#define SYSCNTR_READ_BASE_NS             0x48101000 /* System Counter Read Secure base address */
+/* Non-Secure MSTEXPPIHL Peripheral region */
+#define ETHOS_U55_APB_BASE_NS            0x48102000 /* Ethos-U55 APB Non-Secure base address */
+#define U55_TIMING_ADAPTER_0_BASE_NS     0x48103000 /* Ethos-U55 Timing Adapter 0 APB registers Non-Secure base address */
+#define U55_TIMING_ADAPTER_1_BASE_NS     0x48103200 /* Ethos-U55 Timing Adapter 1 APB registers Non-Secure base address */
+#define FPGA_SBCon_I2C_TOUCH_BASE_NS     0x49200000 /* FPGA - SBCon I2C (Touch) Non-Secure base address */
+#define FPGA_SBCon_I2C_AUDIO_BASE_NS     0x49201000 /* FPGA - SBCon I2C (Audio Conf) Non-Secure base address */
+#define FPGA_SPI_ADC_BASE_NS             0x49202000 /* FPGA - PL022 (SPI ADC) Non-Secure base address */
+#define FPGA_SPI_SHIELD0_BASE_NS         0x49203000 /* FPGA - PL022 (SPI Shield0) Non-Secure base address */
+#define FPGA_SPI_SHIELD1_BASE_NS         0x49204000 /* FPGA - PL022 (SPI Shield1) Non-Secure base address */
+#define SBCon_I2C_SHIELD0_BASE_NS        0x49205000 /* SBCon (I2C - Shield0) Non-Secure base address */
+#define SBCon_I2C_SHIELD1_BASE_NS        0x49206000 /* SBCon (I2C – Shield1) Non-Secure base address */
+#define USER_APB_BASE_NS                 0x49207000 /* USER APB Non-Secure base address */
+#define FPGA_DDR4_EEPROM_BASE_NS         0x49208000 /* FPGA - SBCon I2C (DDR4 EEPROM) Non-Secure base address */
+#define FMC_USER_APB0                    0x4920C000 /* FMC User APB0 */
+#define FMC_USER_APB1                    0x4920D000 /* FMC User APB1 */
+#define FMC_USER_APB2                    0x4920E000 /* FMC User APB2 */
+#define FMC_USER_APB3                    0x4920F000 /* FMC User APB3 */
+#define FPGA_SCC_BASE_NS                 0x49300000 /* FPGA - SCC registers Non-Secure base address */
+#define FPGA_I2S_BASE_NS                 0x49301000 /* FPGA - I2S (Audio) Non-Secure base address */
+#define FPGA_IO_BASE_NS                  0x49302000 /* FPGA - IO (System Ctrl + I/O) Non-Secure base address */
+#define UART0_BASE_NS                    0x49303000 /* UART 0 Non-Secure base address */
+#define UART1_BASE_NS                    0x49304000 /* UART 1 Non-Secure base address */
+#define UART2_BASE_NS                    0x49305000 /* UART 2 Non-Secure base address */
+#define UART3_BASE_NS                    0x49306000 /* UART 3 Non-Secure base address */
+#define UART4_BASE_NS                    0x49307000 /* UART 4 Non-Secure base address */
+#define UART5_BASE_NS                    0x49308000 /* UART 5 Non-Secure base address */
+#define CLCD_Config_Reg_BASE_NS          0x4930A000 /* CLCD Config Reg Non-Secure base address */
+#define RTC_BASE_NS                      0x4930B000 /* RTC Non-Secure base address */
+#define DDR4_BLK0_BASE_NS                0x60000000 /* DDR4 block 0 Non-Secure base address */
+#define DDR4_BLK2_BASE_NS                0x80000000 /* DDR4 block 2 Non-Secure base address */
+#define DDR4_BLK4_BASE_NS                0xA0000000 /* DDR4 block 4 Non-Secure base address */
+#define DDR4_BLK6_BASE_NS                0xC0000000 /* DDR4 block 6 Non-Secure base address */
+
+/* Secure memory map addresses */
+#define ITCM_BASE_S                      0x10000000 /* Instruction TCM Secure base address */
+#define SRAM_BASE_S                      0x11000000 /* CODE SRAM Secure base address */
+#define DTCM0_BASE_S                     0x30000000 /* Data TCM block 0 Secure base address */
+#define DTCM1_BASE_S                     0x30020000 /* Data TCM block 1 Secure base address */
+#define DTCM2_BASE_S                     0x30040000 /* Data TCM block 2 Secure base address */
+#define DTCM3_BASE_S                     0x30060000 /* Data TCM block 3 Secure base address */
+#define ISRAM0_BASE_S                    0x31000000 /* Internal SRAM Area Secure base address */
+#define ISRAM1_BASE_S                    0x31100000 /* Internal SRAM Area Secure base address */
+#define QSPI_SRAM_BASE_S                 0x38000000 /* QSPI SRAM Secure base address */
+/* Secure Subsystem peripheral region */
+#define CPU0_SECCTRL_BASE_S              0x50011000 /* CPU 0 Local Security Control Block Secure base address */
+#define CPU0_PWRCTRL_BASE_S              0x50012000 /* CPU 0 Power Control Block Secure base address */
+#define CPU0_IDENTITY_BASE_S             0x5001F000 /* CPU 0 Identity Block Secure base address */
+#define SSE300_SACFG_BASE_S              0x50080000 /* SSE-300 Secure Access Configuration Register Secure base address */
+#define MPC_ISRAM0_BASE_S                0x50083000 /* Internal SRAM0 Memory Protection Controller Secure base address */
+#define MPC_ISRAM1_BASE_S                0x50084000 /* Internal SRAM1 Memory Protection Controller Secure base address */
+/* Secure MSTEXPPILL Peripheral region */
+#define GPIO0_CMSDK_BASE_S               0x51100000 /* GPIO 0 Secure base address */
+#define GPIO1_CMSDK_BASE_S               0x51101000 /* GPIO 1 Secure base address */
+#define GPIO2_CMSDK_BASE_S               0x51102000 /* GPIO 2 Secure base address */
+#define GPIO3_CMSDK_BASE_S               0x51103000 /* GPIO 3 Secure base address */
+#define FMC_CMSDK_GPIO_0_BASE_S          0x51104000 /* FMC CMSDK GPIO 0 Secure base address */
+#define FMC_CMSDK_GPIO_1_BASE_S          0x51105000 /* FMC CMSDK GPIO 1 Secure base address */
+#define FMC_CMSDK_GPIO_2_BASE_S          0x51106000 /* FMC CMSDK GPIO 2 Secure base address */
+#define FMC_CMSDK_GPIO_3_BASE_S          0x51107000 /* FMC CMSDK GPIO 3 Secure base address */
+#define EXTERNAL_MANAGER0_BASE_S         0x51200000 /* External Manager 0 (Unused) Secure base address */
+#define EXTERNAL_MANAGER1_BASE_S         0x51201000 /* External Manager 1 (Unused) Secure base address */
+#define EXTERNAL_MANAGER2_BASE_S         0x51202000 /* External Manager 2 (Unused) Secure base address */
+#define EXTERNAL_MANAGER3_BASE_S         0x51203000 /* External Manager 3 (Unused) Secure base address */
+#define ETHERNET_BASE_S                  0x51400000 /* Ethernet Secure base address */
+#define USB_BASE_S                       0x51500000 /* USB Secure base address */
+#define USER_APB0_BASE_S                 0x51700000 /* User APB 0 Secure base address */
+#define USER_APB1_BASE_S                 0x51701000 /* User APB 1 Secure base address */
+#define USER_APB2_BASE_S                 0x51702000 /* User APB 2 Secure base address */
+#define USER_APB3_BASE_S                 0x51703000 /* User APB 3 Secure base address */
+#define QSPI_CONFIG_BASE_S               0x51800000 /* QSPI Config Secure base address */
+#define QSPI_WRITE_BASE_S                0x51801000 /* QSPI Write Secure base address */
+#define MPC_SRAM_BASE_S                  0x57000000 /* SRAM Memory Protection Controller Secure base address */
+#define MPC_QSPI_BASE_S                  0x57001000 /* QSPI Memory Protection Controller Secure base address */
+#define MPC_DDR4_BASE_S                  0x57002000 /* DDR4 Memory Protection Controller Secure base address */
+/* Secure Subsystem peripheral region */
+#define SYSTIMER0_ARMV8_M_BASE_S         0x58000000 /* System Timer 0 Secure base address */
+#define SYSTIMER1_ARMV8_M_BASE_S         0x58001000 /* System Timer 1 Secure base address */
+#define SYSTIMER2_ARMV8_M_BASE_S         0x58002000 /* System Timer 0 Secure base address */
+#define SYSTIMER3_ARMV8_M_BASE_S         0x58003000 /* System Timer 1 Secure base address */
+#define SSE300_SYSINFO_BASE_S            0x58020000 /* SSE-300 System info Block Secure base address */
+#define SSE300_SYSCTRL_BASE_S            0x58021000 /* SSE-300 System control Block Secure base address */
+#define SSE300_SYSPPU_BASE_S             0x58022000 /* SSE-300 System Power Policy Unit Secure base address */
+#define SSE300_CPU0PPU_BASE_S            0x58023000 /* SSE-300 CPU 0 Power Policy Unit Secure base address */
+#define SSE300_MGMTPPU_BASE_S            0x58028000 /* SSE-300 Management Power Policy Unit Secure base address */
+#define SSE300_DBGPPU_BASE_S             0x58029000 /* SSE-300 Debug Power Policy Unit Secure base address */
+#define SLOWCLK_WDOG_CMSDK_BASE_S        0x5802E000 /* CMSDK based SLOWCLK Watchdog Secure base address */
+#define SLOWCLK_TIMER_CMSDK_BASE_S       0x5802F000 /* CMSDK based SLOWCLK Timer Secure base address */
+#define SYSWDOG_ARMV8_M_CNTRL_BASE_S     0x58040000 /* Secure Watchdog Timer control frame Secure base address */
+#define SYSWDOG_ARMV8_M_REFRESH_BASE_S   0x58041000 /* Secure Watchdog Timer refresh frame Secure base address */
+#define SYSCNTR_CNTRL_BASE_S             0x58100000 /* System Counter Control Secure base address */
+#define SYSCNTR_READ_BASE_S              0x58101000 /* System Counter Read Secure base address */
+/* Secure MSTEXPPIHL Peripheral region */
+#define ETHOS_U55_APB_BASE_S             0x58102000 /* Ethos-U55 APB Secure base address */
+#define U55_TIMING_ADAPTER_0_BASE_S      0x58103000 /* Ethos-U55 Timing Adapter 0 APB registers Secure base address */
+#define U55_TIMING_ADAPTER_1_BASE_S      0x58103200 /* Ethos-U55 Timing Adapter 1 APB registers Secure base address */
+#define FPGA_SBCon_I2C_TOUCH_BASE_S      0x59200000 /* FPGA - SBCon I2C (Touch) Secure base address */
+#define FPGA_SBCon_I2C_AUDIO_BASE_S      0x59201000 /* FPGA - SBCon I2C (Audio Conf) Secure base address */
+#define FPGA_SPI_ADC_BASE_S              0x59202000 /* FPGA - PL022 (SPI ADC) Secure base address */
+#define FPGA_SPI_SHIELD0_BASE_S          0x59203000 /* FPGA - PL022 (SPI Shield0) Secure base address */
+#define FPGA_SPI_SHIELD1_BASE_S          0x59204000 /* FPGA - PL022 (SPI Shield1) Secure base address */
+#define SBCon_I2C_SHIELD0_BASE_S         0x59205000 /* SBCon (I2C - Shield0) Secure base address */
+#define SBCon_I2C_SHIELD1_BASE_S         0x59206000 /* SBCon (I2C – Shield1) Secure base address */
+#define USER_APB_BASE_S                  0x59207000 /* USER APB Secure base address */
+#define FPGA_DDR4_EEPROM_BASE_S          0x59208000 /* FPGA - SBCon I2C (DDR4 EEPROM) Secure base address */
+#define FMC_USER_APB_0_BASE_S            0x5920C000 /* FMC User APB0 registers Secure base address */
+#define FMC_USER_APB_1_BASE_S            0x5920D000 /* FMC User APB1 registers Secure base address */
+#define FMC_USER_APB_2_BASE_S            0x5920E000 /* FMC User APB2 registers Secure base address */
+#define FMC_USER_APB_3_BASE_S            0x5920F000 /* FMC User APB3 registers Secure base address */
+#define FPGA_SCC_BASE_S                  0x59300000 /* FPGA - SCC registers Secure base address */
+#define FPGA_I2S_BASE_S                  0x59301000 /* FPGA - I2S (Audio) Secure base address */
+#define FPGA_IO_BASE_S                   0x59302000 /* FPGA - IO (System Ctrl + I/O) Secure base address */
+#define UART0_BASE_S                     0x59303000 /* UART 0 Secure base address */
+#define UART1_BASE_S                     0x59304000 /* UART 1 Secure base address */
+#define UART2_BASE_S                     0x59305000 /* UART 2 Secure base address */
+#define UART3_BASE_S                     0x59306000 /* UART 3 Secure base address */
+#define UART4_BASE_S                     0x59307000 /* UART 4 Secure base address */
+#define UART5_BASE_S                     0x59308000 /* UART 5 Secure base address */
+#define CLCD_Config_Reg_BASE_S           0x5930A000 /* CLCD Config Reg Secure base address */
+#define RTC_BASE_S                       0x5930B000 /* RTC Secure base address */
+#define DDR4_BLK1_BASE_S                 0x70000000 /* DDR4 block 1 Secure base address */
+#define DDR4_BLK3_BASE_S                 0x90000000 /* DDR4 block 3 Secure base address */
+#define DDR4_BLK5_BASE_S                 0xB0000000 /* DDR4 block 5 Secure base address */
+#define DDR4_BLK7_BASE_S                 0xD0000000 /* DDR4 block 7 Secure base address */
+
+/* Memory map addresses exempt from memory attribution by both the SAU and IDAU */
+#define SSE300_EWIC_BASE                 0xE0047000 /* External Wakeup Interrupt Controller
+                                                     * Access from Non-secure software is only allowed
+                                                     * if AIRCR.BFHFNMINS is set to 1 */
+
+/* Memory size definitions */
+#define ITCM_SIZE       (0x00080000) /* 512 kB */
+#define DTCM_BLK_SIZE   (0x00020000) /* 128 kB */
+#define DTCM_BLK_NUM    (0x4)        /* Number of DTCM blocks */
+#define SRAM_SIZE       (0x00100000) /* 1 MB */
+#define ISRAM0_SIZE     (0x00100000) /* 1 MB */
+#define ISRAM1_SIZE     (0x00100000) /* 1 MB */
+#define QSPI_SRAM_SIZE  (0x00800000) /* 8 MB */
+#define DDR4_BLK_SIZE   (0x10000000) /* 256 MB */
+#define DDR4_BLK_NUM    (0x8)        /* Number of DDR4 blocks */
+
+/* Defines for Driver MPC's */
+/* SRAM -- 2 MB */
+#define MPC_SRAM_RANGE_BASE_NS   (SRAM_BASE_NS)
+#define MPC_SRAM_RANGE_LIMIT_NS  (SRAM_BASE_NS + SRAM_SIZE-1)
+#define MPC_SRAM_RANGE_OFFSET_NS (0x0)
+#define MPC_SRAM_RANGE_BASE_S    (SRAM_BASE_S)
+#define MPC_SRAM_RANGE_LIMIT_S   (SRAM_BASE_S + SRAM_SIZE-1)
+#define MPC_SRAM_RANGE_OFFSET_S  (0x0)
+
+/* QSPI -- 8 MB*/
+#define MPC_QSPI_RANGE_BASE_NS   (QSPI_SRAM_BASE_NS)
+#define MPC_QSPI_RANGE_LIMIT_NS  (QSPI_SRAM_BASE_NS + QSPI_SRAM_SIZE-1)
+#define MPC_QSPI_RANGE_OFFSET_NS (0x0)
+#define MPC_QSPI_RANGE_BASE_S    (QSPI_SRAM_BASE_S)
+#define MPC_QSPI_RANGE_LIMIT_S   (QSPI_SRAM_BASE_S + QSPI_SRAM_SIZE-1)
+#define MPC_QSPI_RANGE_OFFSET_S  (0x0)
+
+/* ISRAM0 -- 2 MB*/
+#define MPC_ISRAM0_RANGE_BASE_NS   (ISRAM0_BASE_NS)
+#define MPC_ISRAM0_RANGE_LIMIT_NS  (ISRAM0_BASE_NS + ISRAM0_SIZE-1)
+#define MPC_ISRAM0_RANGE_OFFSET_NS (0x0)
+#define MPC_ISRAM0_RANGE_BASE_S    (ISRAM0_BASE_S)
+#define MPC_ISRAM0_RANGE_LIMIT_S   (ISRAM0_BASE_S + ISRAM0_SIZE-1)
+#define MPC_ISRAM0_RANGE_OFFSET_S  (0x0)
+
+/* ISRAM1 -- 2 MB*/
+#define MPC_ISRAM1_RANGE_BASE_NS   (ISRAM1_BASE_NS)
+#define MPC_ISRAM1_RANGE_LIMIT_NS  (ISRAM1_BASE_NS + ISRAM1_SIZE-1)
+#define MPC_ISRAM1_RANGE_OFFSET_NS (0x0)
+#define MPC_ISRAM1_RANGE_BASE_S    (ISRAM1_BASE_S)
+#define MPC_ISRAM1_RANGE_LIMIT_S   (ISRAM1_BASE_S + ISRAM1_SIZE-1)
+#define MPC_ISRAM1_RANGE_OFFSET_S  (0x0)
+
+/* DDR4 -- 2GB (8 * 256 MB) */
+#define MPC_DDR4_BLK0_RANGE_BASE_NS   (DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK0_RANGE_LIMIT_NS  (DDR4_BLK0_BASE_NS + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK0_RANGE_OFFSET_NS (0x0)
+#define MPC_DDR4_BLK1_RANGE_BASE_S    (DDR4_BLK1_BASE_S)
+#define MPC_DDR4_BLK1_RANGE_LIMIT_S   (DDR4_BLK1_BASE_S + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK1_RANGE_OFFSET_S  (DDR4_BLK1_BASE_S - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK2_RANGE_BASE_NS   (DDR4_BLK2_BASE_NS)
+#define MPC_DDR4_BLK2_RANGE_LIMIT_NS  (DDR4_BLK2_BASE_NS + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK2_RANGE_OFFSET_NS (DDR4_BLK2_BASE_NS - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK3_RANGE_BASE_S    (DDR4_BLK3_BASE_S)
+#define MPC_DDR4_BLK3_RANGE_LIMIT_S   (DDR4_BLK3_BASE_S + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK3_RANGE_OFFSET_S  (DDR4_BLK3_BASE_S - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK4_RANGE_BASE_NS   (DDR4_BLK4_BASE_NS)
+#define MPC_DDR4_BLK4_RANGE_LIMIT_NS  (DDR4_BLK4_BASE_NS + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK4_RANGE_OFFSET_NS (DDR4_BLK4_BASE_NS - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK5_RANGE_BASE_S    (DDR4_BLK5_BASE_S)
+#define MPC_DDR4_BLK5_RANGE_LIMIT_S   (DDR4_BLK5_BASE_S + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK5_RANGE_OFFSET_S  (DDR4_BLK5_BASE_S - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK6_RANGE_BASE_NS   (DDR4_BLK6_BASE_NS)
+#define MPC_DDR4_BLK6_RANGE_LIMIT_NS  (DDR4_BLK6_BASE_NS + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK6_RANGE_OFFSET_NS (DDR4_BLK6_BASE_NS - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK7_RANGE_BASE_S    (DDR4_BLK7_BASE_S)
+#define MPC_DDR4_BLK7_RANGE_LIMIT_S   (DDR4_BLK7_BASE_S + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK7_RANGE_OFFSET_S  (DDR4_BLK7_BASE_S - DDR4_BLK0_BASE_NS)
+
+#endif  /* __PLATFORM_BASE_ADDRESS_H__ */

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/region_defs.h
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/region_defs.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016-2022 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __REGION_DEFS_H__
+#define __REGION_DEFS_H__
+
+#include "region_limits.h"
+
+/* **************************************************************
+ * WARNING: this file is parsed both by the C/C++ compiler
+ * and the linker. As a result the syntax must be valid not only
+ * for C/C++ but for the linker scripts too.
+ * Beware of the following limitations:
+ *   - LD (GCC linker) requires white space around operators.
+ *   - UL postfix for macros is not suported by the linker script
+ ****************************************************************/
+
+/* Secure regions */
+#define S_CODE_START     ( S_ROM_ALIAS )
+#define S_CODE_SIZE      ( TOTAL_S_ROM_SIZE )
+#define S_CODE_LIMIT     ( S_CODE_START + S_CODE_SIZE )
+
+#define S_DATA_START     ( S_RAM_ALIAS )
+#define S_DATA_SIZE      ( TOTAL_S_RAM_SIZE )
+#define S_DATA_LIMIT     ( S_DATA_START + S_DATA_SIZE )
+
+#define S_DDR4_START     ( S_DDR4_ALIAS )
+#define S_DDR4_SIZE      ( TOTAL_S_DDR4_SIZE )
+#define S_DDR4_LIMIT     ( S_DDR4_START + S_DDR4_SIZE )
+
+#endif /* __REGION_DEFS_H__ */

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/region_limits.h
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/region_limits.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018-2022 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __REGION_LIMITS_H__
+#define __REGION_LIMITS_H__
+
+/* **************************************************************
+ * WARNING: this file is parsed both by the C/C++ compiler
+ * and the linker. As a result the syntax must be valid not only
+ * for C/C++ but for the linker scripts too.
+ * Beware of the following limitations:
+ *   - LD (GCC linker) requires white space around operators.
+ *   - UL postfix for macros is not suported by the linker script
+ ****************************************************************/
+
+/* Secure Code */
+#define S_ROM_ALIAS               (0x10000000) /* ITCM_BASE_S */
+#define TOTAL_S_ROM_SIZE          (0x00080000) /* 512 kB */
+
+/* Secure Data */
+#define S_RAM_ALIAS               (0x30000000) /* DTCM_BASE_S */
+#define TOTAL_S_RAM_SIZE          (0x00080000) /* 512 kB */
+
+/* Secure DDR4 */
+#define S_DDR4_ALIAS              (0x70000000) /* DDR4_BLK1_BASE_S */
+#define TOTAL_S_DDR4_SIZE         (0x10000000) /* 256 MB */
+
+/* Heap and Stack sizes for secure and nonsecure applications */
+#define HEAP_SIZE                 (0x00000400) /* 1 KiB */
+#define STACK_SIZE                (0x00000400) /* 1 KiB */
+
+#endif /* __REGION_LIMITS_H__ */

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/startup_fvp_sse300_mps3.c
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/startup_fvp_sse300_mps3.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2009-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file is derivative of CMSIS V5.6.0 startup_ARMv81MML.c
+ * Git SHA: b5f0603d6a584d1724d952fd8b0737458b90d62b
+ */
+
+#include "SSE300MPS3.h"
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler Function Prototype
+ *----------------------------------------------------------------------------*/
+typedef void( *pFunc )( void );
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+
+extern void __PROGRAM_START(void) __NO_RETURN;
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+void Reset_Handler  (void) __NO_RETURN;
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+#define DEFAULT_IRQ_HANDLER(handler_name)  \
+void __WEAK __NO_RETURN handler_name(void); \
+void handler_name(void) { \
+    while(1); \
+}
+
+/* Exceptions */
+DEFAULT_IRQ_HANDLER(NMI_Handler)
+DEFAULT_IRQ_HANDLER(HardFault_Handler)
+DEFAULT_IRQ_HANDLER(MemManage_Handler)
+DEFAULT_IRQ_HANDLER(BusFault_Handler)
+DEFAULT_IRQ_HANDLER(UsageFault_Handler)
+DEFAULT_IRQ_HANDLER(SecureFault_Handler)
+DEFAULT_IRQ_HANDLER(SVC_Handler)
+DEFAULT_IRQ_HANDLER(DebugMon_Handler)
+DEFAULT_IRQ_HANDLER(PendSV_Handler)
+DEFAULT_IRQ_HANDLER(SysTick_Handler)
+
+DEFAULT_IRQ_HANDLER(NONSEC_WATCHDOG_RESET_Handler)
+DEFAULT_IRQ_HANDLER(NONSEC_WATCHDOG_Handler)
+DEFAULT_IRQ_HANDLER(SLOWCLK_Timer_Handler)
+DEFAULT_IRQ_HANDLER(TIMER0_Handler)
+DEFAULT_IRQ_HANDLER(TIMER1_Handler)
+DEFAULT_IRQ_HANDLER(TIMER2_Handler)
+DEFAULT_IRQ_HANDLER(MPC_Handler)
+DEFAULT_IRQ_HANDLER(PPC_Handler)
+DEFAULT_IRQ_HANDLER(MSC_Handler)
+DEFAULT_IRQ_HANDLER(BRIDGE_ERROR_Handler)
+DEFAULT_IRQ_HANDLER(MGMT_PPU_Handler)
+DEFAULT_IRQ_HANDLER(SYS_PPU_Handler)
+DEFAULT_IRQ_HANDLER(CPU0_PPU_Handler)
+DEFAULT_IRQ_HANDLER(DEBUG_PPU_Handler)
+DEFAULT_IRQ_HANDLER(TIMER3_Handler)
+DEFAULT_IRQ_HANDLER(CTI_REQ0_IRQHandler)
+DEFAULT_IRQ_HANDLER(CTI_REQ1_IRQHandler)
+
+DEFAULT_IRQ_HANDLER(System_Timestamp_Counter_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX0_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX0_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX1_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX1_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX2_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX2_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX3_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX3_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX4_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX4_Handler)
+DEFAULT_IRQ_HANDLER(UART0_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UART1_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UART2_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UART3_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UART4_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UARTOVF_Handler)
+DEFAULT_IRQ_HANDLER(ETHERNET_Handler)
+DEFAULT_IRQ_HANDLER(I2S_Handler)
+DEFAULT_IRQ_HANDLER(TOUCH_SCREEN_Handler)
+DEFAULT_IRQ_HANDLER(USB_Handler)
+DEFAULT_IRQ_HANDLER(SPI_ADC_Handler)
+DEFAULT_IRQ_HANDLER(SPI_SHIELD0_Handler)
+DEFAULT_IRQ_HANDLER(SPI_SHIELD1_Handler)
+DEFAULT_IRQ_HANDLER(ETHOS_U55_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_Combined_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_Combined_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_Combined_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_Combined_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_0_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_1_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_2_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_3_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_4_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_5_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_6_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_7_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_8_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_9_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_10_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_11_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_12_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_13_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_14_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_15_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_0_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_1_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_2_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_3_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_4_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_5_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_6_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_7_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_8_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_9_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_10_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_11_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_12_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_13_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_14_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_15_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_0_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_1_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_2_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_3_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_4_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_5_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_6_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_7_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_8_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_9_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_10_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_11_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_12_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_13_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_14_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_15_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_0_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_1_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_2_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_3_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX5_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX5_Handler)
+DEFAULT_IRQ_HANDLER(UART5_Handler)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const pFunc __VECTOR_TABLE[496];
+       const pFunc __VECTOR_TABLE[496] __VECTOR_TABLE_ATTRIBUTE = {
+  (pFunc)(&__INITIAL_SP),           /*      Initial Stack Pointer */
+  Reset_Handler,                    /*      Reset Handler */
+  NMI_Handler,                      /* -14: NMI Handler */
+  HardFault_Handler,                /* -13: Hard Fault Handler */
+  MemManage_Handler,                /* -12: MPU Fault Handler */
+  BusFault_Handler,                 /* -11: Bus Fault Handler */
+  UsageFault_Handler,               /* -10: Usage Fault Handler */
+  SecureFault_Handler,              /*  -9: Secure Fault Handler */
+  0,                                /*      Reserved */
+  0,                                /*      Reserved */
+  0,                                /*      Reserved */
+  SVC_Handler,                      /*  -5: SVCall Handler */
+  DebugMon_Handler,                 /*  -4: Debug Monitor Handler */
+  0,                                /*      Reserved */
+  PendSV_Handler,                   /*  -2: PendSV Handler */
+  SysTick_Handler,                  /*  -1: SysTick Handler */
+
+  NONSEC_WATCHDOG_RESET_Handler,    /*   0: Non-Secure Watchdog Reset Handler */
+  NONSEC_WATCHDOG_Handler,          /*   1: Non-Secure Watchdog Handler */
+  SLOWCLK_Timer_Handler,            /*   2: SLOWCLK Timer Handler */
+  TIMER0_Handler,                   /*   3: TIMER 0 Handler */
+  TIMER1_Handler,                   /*   4: TIMER 1 Handler */
+  TIMER2_Handler,                   /*   5: TIMER 2 Handler */
+  0,                                /*   6: Reserved */
+  0,                                /*   7: Reserved */
+  0,                                /*   8: Reserved */
+  MPC_Handler,                      /*   9: MPC Combined (Secure) Handler */
+  PPC_Handler,                      /*  10: PPC Combined (Secure) Handler */
+  MSC_Handler,                      /*  11: MSC Combined (Secure) Handler */
+  BRIDGE_ERROR_Handler,             /*  12: Bridge Error (Secure) Handler */
+  0,                                /*  13: Reserved */
+  MGMT_PPU_Handler,                 /*  14: MGMT PPU Handler */
+  SYS_PPU_Handler,                  /*  15: SYS PPU Handler */
+  CPU0_PPU_Handler,                 /*  16: CPU0 PPU Handler */
+  0,                                /*  17: Reserved */
+  0,                                /*  18: Reserved */
+  0,                                /*  19: Reserved */
+  0,                                /*  20: Reserved */
+  0,                                /*  21: Reserved */
+  0,                                /*  22: Reserved */
+  0,                                /*  23: Reserved */
+  0,                                /*  24: Reserved */
+  0,                                /*  25: Reserved */
+  DEBUG_PPU_Handler,                /*  26: DEBUG PPU Handler */
+  TIMER3_Handler,                   /*  27: TIMER 3 Handler */
+  CTI_REQ0_IRQHandler,              /*  28: CTI request 0 IRQ Handler */
+  CTI_REQ1_IRQHandler,              /*  29: CTI request 1 IRQ Handler */
+  0,                                /*  30: Reserved */
+  0,                                /*  31: Reserved */
+
+  /* External interrupts */
+  System_Timestamp_Counter_Handler, /*  32: System timestamp counter Handler */
+  UARTRX0_Handler,                  /*  33: UART 0 RX Handler */
+  UARTTX0_Handler,                  /*  34: UART 0 TX Handler */
+  UARTRX1_Handler,                  /*  35: UART 1 RX Handler */
+  UARTTX1_Handler,                  /*  36: UART 1 TX Handler */
+  UARTRX2_Handler,                  /*  37: UART 2 RX Handler */
+  UARTTX2_Handler,                  /*  38: UART 2 TX Handler */
+  UARTRX3_Handler,                  /*  39: UART 3 RX Handler */
+  UARTTX3_Handler,                  /*  40: UART 3 TX Handler */
+  UARTRX4_Handler,                  /*  41: UART 4 RX Handler */
+  UARTTX4_Handler,                  /*  42: UART 4 TX Handler */
+  UART0_Combined_Handler,           /*  43: UART 0 Combined Handler */
+  UART1_Combined_Handler,           /*  44: UART 1 Combined Handler */
+  UART2_Combined_Handler,           /*  45: UART 2 Combined Handler */
+  UART3_Combined_Handler,           /*  46: UART 3 Combined Handler */
+  UART4_Combined_Handler,           /*  47: UART 4 Combined Handler */
+  UARTOVF_Handler,                  /*  48: UART 0, 1, 2, 3, 4 & 5 Overflow Handler */
+  ETHERNET_Handler,                 /*  49: Ethernet Handler */
+  I2S_Handler,                      /*  50: Audio I2S Handler */
+  TOUCH_SCREEN_Handler,             /*  51: Touch Screen Handler */
+  USB_Handler,                      /*  52: USB Handler */
+  SPI_ADC_Handler,                  /*  53: SPI ADC Handler */
+  SPI_SHIELD0_Handler,              /*  54: SPI (Shield 0) Handler */
+  SPI_SHIELD1_Handler,              /*  55: SPI (Shield 0) Handler */
+  ETHOS_U55_Handler,                /*  56: Ethos-U55 Handler */
+  0,                                /*  57: Reserved */
+  0,                                /*  58: Reserved */
+  0,                                /*  59: Reserved */
+  0,                                /*  60: Reserved */
+  0,                                /*  61: Reserved */
+  0,                                /*  62: Reserved */
+  0,                                /*  63: Reserved */
+  0,                                /*  64: Reserved */
+  0,                                /*  65: Reserved */
+  0,                                /*  66: Reserved */
+  0,                                /*  67: Reserved */
+  0,                                /*  68: Reserved */
+  GPIO0_Combined_Handler,           /*  69: GPIO 0 Combined Handler */
+  GPIO1_Combined_Handler,           /*  70: GPIO 1 Combined Handler */
+  GPIO2_Combined_Handler,           /*  71: GPIO 2 Combined Handler */
+  GPIO3_Combined_Handler,           /*  72: GPIO 3 Combined Handler */
+  GPIO0_0_Handler,                  /*  73: GPIO0 Pin 0 Handler */
+  GPIO0_1_Handler,                  /*  74: GPIO0 Pin 1 Handler */
+  GPIO0_2_Handler,                  /*  75: GPIO0 Pin 2 Handler */
+  GPIO0_3_Handler,                  /*  76: GPIO0 Pin 3 Handler */
+  GPIO0_4_Handler,                  /*  77: GPIO0 Pin 4 Handler */
+  GPIO0_5_Handler,                  /*  78: GPIO0 Pin 5 Handler */
+  GPIO0_6_Handler,                  /*  79: GPIO0 Pin 6 Handler */
+  GPIO0_7_Handler,                  /*  80: GPIO0 Pin 7 Handler */
+  GPIO0_8_Handler,                  /*  81: GPIO0 Pin 8 Handler */
+  GPIO0_9_Handler,                  /*  82: GPIO0 Pin 9 Handler */
+  GPIO0_10_Handler,                 /*  83: GPIO0 Pin 10 Handler */
+  GPIO0_11_Handler,                 /*  84: GPIO0 Pin 11 Handler */
+  GPIO0_12_Handler,                 /*  85: GPIO0 Pin 12 Handler */
+  GPIO0_13_Handler,                 /*  86: GPIO0 Pin 13 Handler */
+  GPIO0_14_Handler,                 /*  87: GPIO0 Pin 14 Handler */
+  GPIO0_15_Handler,                 /*  88: GPIO0 Pin 15 Handler */
+  GPIO1_0_Handler,                  /*  89: GPIO1 Pin 0 Handler */
+  GPIO1_1_Handler,                  /*  90: GPIO1 Pin 1 Handler */
+  GPIO1_2_Handler,                  /*  91: GPIO1 Pin 2 Handler */
+  GPIO1_3_Handler,                  /*  92: GPIO1 Pin 3 Handler */
+  GPIO1_4_Handler,                  /*  93: GPIO1 Pin 4 Handler */
+  GPIO1_5_Handler,                  /*  94: GPIO1 Pin 5 Handler */
+  GPIO1_6_Handler,                  /*  95: GPIO1 Pin 6 Handler */
+  GPIO1_7_Handler,                  /*  96: GPIO1 Pin 7 Handler */
+  GPIO1_8_Handler,                  /*  97: GPIO1 Pin 8 Handler */
+  GPIO1_9_Handler,                  /*  98: GPIO1 Pin 9 Handler */
+  GPIO1_10_Handler,                 /*  99: GPIO1 Pin 10 Handler */
+  GPIO1_11_Handler,                 /*  100: GPIO1 Pin 11 Handler */
+  GPIO1_12_Handler,                 /*  101: GPIO1 Pin 12 Handler */
+  GPIO1_13_Handler,                 /*  102: GPIO1 Pin 13 Handler */
+  GPIO1_14_Handler,                 /*  103: GPIO1 Pin 14 Handler */
+  GPIO1_15_Handler,                 /*  104: GPIO1 Pin 15 Handler */
+  GPIO2_0_Handler,                  /*  105: GPIO2 Pin 0 Handler */
+  GPIO2_1_Handler,                  /*  106: GPIO2 Pin 1 Handler */
+  GPIO2_2_Handler,                  /*  107: GPIO2 Pin 2 Handler */
+  GPIO2_3_Handler,                  /*  108: GPIO2 Pin 3 Handler */
+  GPIO2_4_Handler,                  /*  109: GPIO2 Pin 4 Handler */
+  GPIO2_5_Handler,                  /*  110: GPIO2 Pin 5 Handler */
+  GPIO2_6_Handler,                  /*  111: GPIO2 Pin 6 Handler */
+  GPIO2_7_Handler,                  /*  112: GPIO2 Pin 7 Handler */
+  GPIO2_8_Handler,                  /*  113: GPIO2 Pin 8 Handler */
+  GPIO2_9_Handler,                  /*  114: GPIO2 Pin 9 Handler */
+  GPIO2_10_Handler,                 /*  115: GPIO2 Pin 10 Handler */
+  GPIO2_11_Handler,                 /*  116: GPIO2 Pin 11 Handler */
+  GPIO2_12_Handler,                 /*  117: GPIO2 Pin 12 Handler */
+  GPIO2_13_Handler,                 /*  118: GPIO2 Pin 13 Handler */
+  GPIO2_14_Handler,                 /*  119: GPIO2 Pin 14 Handler */
+  GPIO2_15_Handler,                 /*  120: GPIO2 Pin 15 Handler */
+  GPIO3_0_Handler,                  /*  121: GPIO3 Pin 0 Handler */
+  GPIO3_1_Handler,                  /*  122: GPIO3 Pin 1 Handler */
+  GPIO3_2_Handler,                  /*  123: GPIO3 Pin 2 Handler */
+  GPIO3_3_Handler,                  /*  124: GPIO3 Pin 3 Handler */
+  UARTRX5_Handler,                  /*  125: UART 5 RX Interrupt */
+  UARTTX5_Handler,                  /*  126: UART 5 TX Interrupt */
+  UART5_Handler,                    /*  127: UART 5 combined Interrupt */
+  0,                                /*  128: Reserved */
+  0,                                /*  129: Reserved */
+  0,                                /*  130: Reserved */
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+void Reset_Handler(void)
+{
+  __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/system_SSE300MPS3.c
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/system_SSE300MPS3.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2009-2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file is derivative of CMSIS V5.6.0 system_ARMv81MML.c
+ * Git SHA: b5f0603d6a584d1724d952fd8b0737458b90d62b
+ */
+
+#include "SSE300MPS3.h"
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+ #define  XTAL             (32000000UL)
+ #define  SYSTEM_CLOCK     (XTAL)
+ #define  PERIPHERAL_CLOCK (25000000UL)
+
+/*----------------------------------------------------------------------------
+  Externals
+ *----------------------------------------------------------------------------*/
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+    extern uint32_t __VECTOR_TABLE;
+#endif
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;
+uint32_t PeripheralClock = PERIPHERAL_CLOCK;
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+    SystemCoreClock = SYSTEM_CLOCK;
+    PeripheralClock = PERIPHERAL_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+    SCB->VTOR = (uint32_t)(&__VECTOR_TABLE);
+#endif
+
+#if (defined (__FPU_USED) && (__FPU_USED == 1U)) || \
+    (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE >= 1U))
+    SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                   (3U << 11U*2U)  );         /* enable CP11 Full Access */
+
+    /* Set CPDLPSTATE.CLPSTATE to 0, so PDCORE will not enter low-power state. Set
+     * CPDLPSTATE.ELPSTATE to 0, to stop the processor from trying to switch the EPU
+     * into retention state
+     */
+    PWRMODCTL->CPDLPSTATE &= 0xFFFFFF00UL;
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+    SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+    /* Enable Loop and branch info cache */
+    SCB->CCR |= SCB_CCR_LOB_Msk;
+    __DSB();
+    __ISB();
+
+}

--- a/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/system_SSE300MPS3.h
+++ b/Layer/Target/CM55_VHT_AC6/RTE/SSE-300-MPS3/system_SSE300MPS3.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2009-2020 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file is derivative of CMSIS V5.6.0 system_ARMv81MML.h
+ * Git SHA: b5f0603d6a584d1724d952fd8b0737458b90d62b
+ */
+
+#ifndef __SYSTEM_CORE_INIT_H__
+#define __SYSTEM_CORE_INIT_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern uint32_t SystemCoreClock;  /*!< System Clock Frequency (Core Clock)  */
+extern uint32_t PeripheralClock;  /*!< Peripheral Clock Frequency */
+
+/**
+ * \brief  Initializes the system
+ */
+extern void SystemInit(void);
+
+/**
+ * \brief  Restores system core clock
+ */
+extern void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_CORE_INIT_H__ */

--- a/Layer/Target/CM55_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM55_VHT_AC6/Target.clayer.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: ARM::V2M_MPS3_SSE_300_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: ARM::CMSIS Driver:USART
+
+    - component: ARM::Device:Startup&Baremetal
+    - component: ARM::Device:Definition
+
+    - component: ARM::Native Driver:SysCounter
+    - component: ARM::Native Driver:SysTimer
+    - component: ARM::Native Driver:Timeout
+    - component: ARM::Native Driver:UART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM55_VHT_AC6/vht_config.txt
+++ b/Layer/Target/CM55_VHT_AC6/vht_config.txt
@@ -1,0 +1,9 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+cpu_core.core_clk.mul=100000000                                # (int   , init-time) default = '0x17d7840' : Clock Rate Multiplier. This parameter is not exposed via CADI and can only be set in LISA
+cpu_core.mps3_board.telnetterminal0.start_telnet=0             # (bool  , init-time) default = '1'      : Start telnet if nothing connected
+cpu_core.mps3_board.uart0.out_file=-                           # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+cpu_core.mps3_board.uart0.shutdown_on_eot=1                    # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+cpu_core.mps3_board.visualisation.disable-visualisation=1      # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM7_DP_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM7_DP_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM7_DP_VHT_AC6/RTE/Device/CMSDK_CM7_DP_VHT/RTE_Device.h
+++ b/Layer/Target/CM7_DP_VHT_AC6/RTE/Device/CMSDK_CM7_DP_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM7_DP_VHT_AC6/RTE/Device/CMSDK_CM7_DP_VHT/ac6_arm.sct
+++ b/Layer/Target/CM7_DP_VHT_AC6/RTE/Device/CMSDK_CM7_DP_VHT/ac6_arm.sct
@@ -1,0 +1,76 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m7 -xc
+; command above MUST be in first line (no comment above!)
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE)    /* starts at end of RAM */
+#define __HEAP_BASE    (AlignExpr(+0, 8))           /* starts after RW_RAM section, 8 byte aligned */
+
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+#define __RO_BASE       __ROM_BASE
+#define __RO_SIZE       __ROM_SIZE
+
+#define __RW_BASE       __RAM_BASE
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE)
+
+
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_RAM __RW_BASE __RW_SIZE  {                     ; RW data
+   .ANY (+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+}

--- a/Layer/Target/CM7_DP_VHT_AC6/RTE/Device/CMSDK_CM7_DP_VHT/startup_CMSDK_CM7.c
+++ b/Layer/Target/CM7_DP_VHT_AC6/RTE/Device/CMSDK_CM7_DP_VHT/startup_CMSDK_CM7.c
@@ -1,0 +1,425 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM7.c
+ * @brief    CMSIS Startup File for CMSDK_M7 Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM7)    || defined (CMSDK_CM7_VHT)
+  #include "CMSDK_CM7.h"
+#elif defined (CMSDK_CM7_SP) || defined (CMSDK_CM7_SP_VHT)
+  #include "CMSDK_CM7_SP.h"
+#elif defined (CMSDK_CM7_DP) || defined (CMSDK_CM7_DP_VHT)
+  #include "CMSDK_CM7_DP.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM7_VHT || defined CMSDK_CM7_SP_VHT || defined CMSDK_CM7_DP_VHT
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler,                          /*  31 GPIO 0 individual interrupt ( 7) */
+  0,                                        /*  32 Reserved */
+  0,                                        /*  33 Reserved */
+  0,                                        /*  34 Reserved */
+  0,                                        /*  35 Reserved */
+  0,                                        /*  36 Reserved */
+  0,                                        /*  37 Reserved */
+  0,                                        /*  38 Reserved */
+  0,                                        /*  39 Reserved */
+  0,                                        /*  40 Reserved */
+  0,                                        /*  41 Reserved */
+  0,                                        /*  42 Reserved */
+  0,                                        /*  43 Reserved */
+  0,                                        /*  44 Reserved */
+  0,                                        /*  45 Reserved */
+  0,                                        /*  46 Reserved */
+  0,                                        /*  47 Reserved */
+  0,                                        /*  48 Reserved */
+  0,                                        /*  49 Reserved */
+  0,                                        /*  50 Reserved */
+  0,                                        /*  51 Reserved */
+  0,                                        /*  52 Reserved */
+  0,                                        /*  53 Reserved */
+  0,                                        /*  54 Reserved */
+  0,                                        /*  55 Reserved */
+  0,                                        /*  56 Reserved */
+  0,                                        /*  57 Reserved */
+  0,                                        /*  58 Reserved */
+  0,                                        /*  59 Reserved */
+  0,                                        /*  60 Reserved */
+  0,                                        /*  61 Reserved */
+  0,                                        /*  62 Reserved */
+  0,                                        /*  63 Reserved */
+  0,                                        /*  64 Reserved */
+  0,                                        /*  65 Reserved */
+  0,                                        /*  66 Reserved */
+  0,                                        /*  67 Reserved */
+  0,                                        /*  68 Reserved */
+  0,                                        /*  69 Reserved */
+  0,                                        /*  70 Reserved */
+  0,                                        /*  71 Reserved */
+  0,                                        /*  72 Reserved */
+  0,                                        /*  73 Reserved */
+  0,                                        /*  74 Reserved */
+  0,                                        /*  75 Reserved */
+  0,                                        /*  76 Reserved */
+  0,                                        /*  77 Reserved */
+  0,                                        /*  78 Reserved */
+  0,                                        /*  79 Reserved */
+  0,                                        /*  80 Reserved */
+  0,                                        /*  81 Reserved */
+  0,                                        /*  82 Reserved */
+  0,                                        /*  83 Reserved */
+  0,                                        /*  84 Reserved */
+  0,                                        /*  85 Reserved */
+  0,                                        /*  86 Reserved */
+  0,                                        /*  87 Reserved */
+  0,                                        /*  88 Reserved */
+  0,                                        /*  89 Reserved */
+  0,                                        /*  90 Reserved */
+  0,                                        /*  91 Reserved */
+  0,                                        /*  92 Reserved */
+  0,                                        /*  93 Reserved */
+  0,                                        /*  94 Reserved */
+  0,                                        /*  95 Reserved */
+  0,                                        /*  96 Reserved */
+  0,                                        /*  97 Reserved */
+  0,                                        /*  98 Reserved */
+  0,                                        /*  99 Reserved */
+  0,                                        /* 100 Reserved */
+  0,                                        /* 101 Reserved */
+  0,                                        /* 102 Reserved */
+  0,                                        /* 103 Reserved */
+  0,                                        /* 104 Reserved */
+  0,                                        /* 105 Reserved */
+  0,                                        /* 106 Reserved */
+  0,                                        /* 107 Reserved */
+  0,                                        /* 108 Reserved */
+  0,                                        /* 109 Reserved */
+  0,                                        /* 110 Reserved */
+  0,                                        /* 111 Reserved */
+  0,                                        /* 112 Reserved */
+  0,                                        /* 113 Reserved */
+  0,                                        /* 114 Reserved */
+  0,                                        /* 115 Reserved */
+  0,                                        /* 116 Reserved */
+  0,                                        /* 117 Reserved */
+  0,                                        /* 118 Reserved */
+  0,                                        /* 119 Reserved */
+  0,                                        /* 120 Reserved */
+  0,                                        /* 121 Reserved */
+  0,                                        /* 122 Reserved */
+  0,                                        /* 123 Reserved */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined CMSDK_CM7_VHT || defined CMSDK_CM7_SP_VHT || defined CMSDK_CM7_DP_VHT
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM7_DP_VHT_AC6/RTE/Device/CMSDK_CM7_DP_VHT/system_CMSDK_CM7.c
+++ b/Layer/Target/CM7_DP_VHT_AC6/RTE/Device/CMSDK_CM7_DP_VHT/system_CMSDK_CM7.c
@@ -1,0 +1,87 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM7.c
+ * @brief    CMSIS System Source File for CMSDK_CM7 Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM7)    || defined (CMSDK_CM7_VHT)
+  #include "CMSDK_CM7.h"
+#elif defined (CMSDK_CM7_SP) || defined (CMSDK_CM7_SP_VHT)
+  #include "CMSDK_CM7_SP.h"
+#elif defined (CMSDK_CM7_DP) || defined (CMSDK_CM7_DP_VHT)
+  #include "CMSDK_CM7_DP.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM7_DP_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM7_DP_VHT_AC6/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM7_DP_VHT_AC6/vht_config.txt
+++ b/Layer/Target/CM7_DP_VHT_AC6/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM7_DP_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM7_DP_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM7_DP_VHT_GCC/RTE/Device/CMSDK_CM7_DP_VHT/RTE_Device.h
+++ b/Layer/Target/CM7_DP_VHT_GCC/RTE/Device/CMSDK_CM7_DP_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM7_DP_VHT_GCC/RTE/Device/CMSDK_CM7_DP_VHT/gcc_arm.ld
+++ b/Layer/Target/CM7_DP_VHT_GCC/RTE/Device/CMSDK_CM7_DP_VHT/gcc_arm.ld
@@ -1,0 +1,279 @@
+/******************************************************************************
+ * @file     gcc_arm.ld
+ * @brief    GNU Linker Script for Cortex-M based device
+ ******************************************************************************/
+
+/*
+; -------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__ROM_BASE = 0x00000000;
+__ROM_SIZE = 0x00040000;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ -----------------------------------------------------------------------------*/
+__RAM_BASE = 0x20000000;
+__RAM_SIZE = 0x00020000;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00000400;
+__HEAP_SIZE  = 0x00000C00;
+
+/*
+; -------------------- <<< end of configuration section >>> -------------------
+ */
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  /*
+   * SG veneers:
+   * All SG veneers are placed in the special output section .gnu.sgstubs. Its start address
+   * must be set, either with the command line option ‘--section-start’ or in a linker script,
+   * to indicate where to place these veneers in memory.
+   */
+/*
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > FLASH
+*/
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__) / 4)
+    /* Add each additional bss section here */
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /**
+   * Location counter can end up 2byte aligned with narrow Thumb code but
+   * __etext is assumed by startup code to be the LMA of a section in RAM
+   * which must be 4byte aligned
+   */
+  __etext = ALIGN (4);
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  __etext2 = ALIGN (4);
+
+  .data2 : AT (__etext2)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (COPY) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/Layer/Target/CM7_DP_VHT_GCC/RTE/Device/CMSDK_CM7_DP_VHT/startup_CMSDK_CM7.c
+++ b/Layer/Target/CM7_DP_VHT_GCC/RTE/Device/CMSDK_CM7_DP_VHT/startup_CMSDK_CM7.c
@@ -1,0 +1,425 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM7.c
+ * @brief    CMSIS Startup File for CMSDK_M7 Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM7)    || defined (CMSDK_CM7_VHT)
+  #include "CMSDK_CM7.h"
+#elif defined (CMSDK_CM7_SP) || defined (CMSDK_CM7_SP_VHT)
+  #include "CMSDK_CM7_SP.h"
+#elif defined (CMSDK_CM7_DP) || defined (CMSDK_CM7_DP_VHT)
+  #include "CMSDK_CM7_DP.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM7_VHT || defined CMSDK_CM7_SP_VHT || defined CMSDK_CM7_DP_VHT
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler,                          /*  31 GPIO 0 individual interrupt ( 7) */
+  0,                                        /*  32 Reserved */
+  0,                                        /*  33 Reserved */
+  0,                                        /*  34 Reserved */
+  0,                                        /*  35 Reserved */
+  0,                                        /*  36 Reserved */
+  0,                                        /*  37 Reserved */
+  0,                                        /*  38 Reserved */
+  0,                                        /*  39 Reserved */
+  0,                                        /*  40 Reserved */
+  0,                                        /*  41 Reserved */
+  0,                                        /*  42 Reserved */
+  0,                                        /*  43 Reserved */
+  0,                                        /*  44 Reserved */
+  0,                                        /*  45 Reserved */
+  0,                                        /*  46 Reserved */
+  0,                                        /*  47 Reserved */
+  0,                                        /*  48 Reserved */
+  0,                                        /*  49 Reserved */
+  0,                                        /*  50 Reserved */
+  0,                                        /*  51 Reserved */
+  0,                                        /*  52 Reserved */
+  0,                                        /*  53 Reserved */
+  0,                                        /*  54 Reserved */
+  0,                                        /*  55 Reserved */
+  0,                                        /*  56 Reserved */
+  0,                                        /*  57 Reserved */
+  0,                                        /*  58 Reserved */
+  0,                                        /*  59 Reserved */
+  0,                                        /*  60 Reserved */
+  0,                                        /*  61 Reserved */
+  0,                                        /*  62 Reserved */
+  0,                                        /*  63 Reserved */
+  0,                                        /*  64 Reserved */
+  0,                                        /*  65 Reserved */
+  0,                                        /*  66 Reserved */
+  0,                                        /*  67 Reserved */
+  0,                                        /*  68 Reserved */
+  0,                                        /*  69 Reserved */
+  0,                                        /*  70 Reserved */
+  0,                                        /*  71 Reserved */
+  0,                                        /*  72 Reserved */
+  0,                                        /*  73 Reserved */
+  0,                                        /*  74 Reserved */
+  0,                                        /*  75 Reserved */
+  0,                                        /*  76 Reserved */
+  0,                                        /*  77 Reserved */
+  0,                                        /*  78 Reserved */
+  0,                                        /*  79 Reserved */
+  0,                                        /*  80 Reserved */
+  0,                                        /*  81 Reserved */
+  0,                                        /*  82 Reserved */
+  0,                                        /*  83 Reserved */
+  0,                                        /*  84 Reserved */
+  0,                                        /*  85 Reserved */
+  0,                                        /*  86 Reserved */
+  0,                                        /*  87 Reserved */
+  0,                                        /*  88 Reserved */
+  0,                                        /*  89 Reserved */
+  0,                                        /*  90 Reserved */
+  0,                                        /*  91 Reserved */
+  0,                                        /*  92 Reserved */
+  0,                                        /*  93 Reserved */
+  0,                                        /*  94 Reserved */
+  0,                                        /*  95 Reserved */
+  0,                                        /*  96 Reserved */
+  0,                                        /*  97 Reserved */
+  0,                                        /*  98 Reserved */
+  0,                                        /*  99 Reserved */
+  0,                                        /* 100 Reserved */
+  0,                                        /* 101 Reserved */
+  0,                                        /* 102 Reserved */
+  0,                                        /* 103 Reserved */
+  0,                                        /* 104 Reserved */
+  0,                                        /* 105 Reserved */
+  0,                                        /* 106 Reserved */
+  0,                                        /* 107 Reserved */
+  0,                                        /* 108 Reserved */
+  0,                                        /* 109 Reserved */
+  0,                                        /* 110 Reserved */
+  0,                                        /* 111 Reserved */
+  0,                                        /* 112 Reserved */
+  0,                                        /* 113 Reserved */
+  0,                                        /* 114 Reserved */
+  0,                                        /* 115 Reserved */
+  0,                                        /* 116 Reserved */
+  0,                                        /* 117 Reserved */
+  0,                                        /* 118 Reserved */
+  0,                                        /* 119 Reserved */
+  0,                                        /* 120 Reserved */
+  0,                                        /* 121 Reserved */
+  0,                                        /* 122 Reserved */
+  0,                                        /* 123 Reserved */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined CMSDK_CM7_VHT || defined CMSDK_CM7_SP_VHT || defined CMSDK_CM7_DP_VHT
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM7_DP_VHT_GCC/RTE/Device/CMSDK_CM7_DP_VHT/system_CMSDK_CM7.c
+++ b/Layer/Target/CM7_DP_VHT_GCC/RTE/Device/CMSDK_CM7_DP_VHT/system_CMSDK_CM7.c
@@ -1,0 +1,87 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM7.c
+ * @brief    CMSIS System Source File for CMSDK_CM7 Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM7)    || defined (CMSDK_CM7_VHT)
+  #include "CMSDK_CM7.h"
+#elif defined (CMSDK_CM7_SP) || defined (CMSDK_CM7_SP_VHT)
+  #include "CMSDK_CM7_SP.h"
+#elif defined (CMSDK_CM7_DP) || defined (CMSDK_CM7_DP_VHT)
+  #include "CMSDK_CM7_DP.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM7_DP_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM7_DP_VHT_GCC/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM7_DP_VHT_GCC/vht_config.txt
+++ b/Layer/Target/CM7_DP_VHT_GCC/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM7_SP_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM7_SP_VHT_AC6/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM7_SP_VHT_AC6/RTE/Device/CMSDK_CM7_SP_VHT/RTE_Device.h
+++ b/Layer/Target/CM7_SP_VHT_AC6/RTE/Device/CMSDK_CM7_SP_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM7_SP_VHT_AC6/RTE/Device/CMSDK_CM7_SP_VHT/ac6_arm.sct
+++ b/Layer/Target/CM7_SP_VHT_AC6/RTE/Device/CMSDK_CM7_SP_VHT/ac6_arm.sct
@@ -1,0 +1,76 @@
+#! armclang -E --target=arm-arm-none-eabi -mcpu=cortex-m7 -xc
+; command above MUST be in first line (no comment above!)
+
+/*
+;-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+*/
+
+/*--------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __ROM_BASE      0x00000000
+#define __ROM_SIZE      0x00080000
+
+/*--------------------- Embedded RAM Configuration ---------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __RAM_BASE      0x20000000
+#define __RAM_SIZE      0x00040000
+
+/*--------------------- Stack / Heap Configuration ---------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ *----------------------------------------------------------------------------*/
+#define __STACK_SIZE    0x00000200
+#define __HEAP_SIZE     0x00000C00
+
+/*
+;------------- <<< end of configuration section >>> ---------------------------
+*/
+
+
+/*----------------------------------------------------------------------------
+  User Stack & Heap boundary definition
+ *----------------------------------------------------------------------------*/
+#define __STACK_TOP    (__RAM_BASE + __RAM_SIZE)    /* starts at end of RAM */
+#define __HEAP_BASE    (AlignExpr(+0, 8))           /* starts after RW_RAM section, 8 byte aligned */
+
+
+/*----------------------------------------------------------------------------
+  Scatter File Definitions definition
+ *----------------------------------------------------------------------------*/
+#define __RO_BASE       __ROM_BASE
+#define __RO_SIZE       __ROM_SIZE
+
+#define __RW_BASE       __RAM_BASE
+#define __RW_SIZE      (__RAM_SIZE - __STACK_SIZE - __HEAP_SIZE)
+
+
+LR_ROM __RO_BASE __RO_SIZE  {                       ; load region size_region
+  ER_ROM __RO_BASE __RO_SIZE  {                     ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+   .ANY (+XO)
+  }
+
+  RW_RAM __RW_BASE __RW_SIZE  {                     ; RW data
+   .ANY (+RW +ZI)
+  }
+
+#if __HEAP_SIZE > 0
+  ARM_LIB_HEAP  __HEAP_BASE EMPTY  __HEAP_SIZE  {   ; Reserve empty region for heap
+  }
+#endif
+
+  ARM_LIB_STACK __STACK_TOP EMPTY -__STACK_SIZE {   ; Reserve empty region for stack
+  }
+}

--- a/Layer/Target/CM7_SP_VHT_AC6/RTE/Device/CMSDK_CM7_SP_VHT/startup_CMSDK_CM7.c
+++ b/Layer/Target/CM7_SP_VHT_AC6/RTE/Device/CMSDK_CM7_SP_VHT/startup_CMSDK_CM7.c
@@ -1,0 +1,425 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM7.c
+ * @brief    CMSIS Startup File for CMSDK_M7 Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM7)    || defined (CMSDK_CM7_VHT)
+  #include "CMSDK_CM7.h"
+#elif defined (CMSDK_CM7_SP) || defined (CMSDK_CM7_SP_VHT)
+  #include "CMSDK_CM7_SP.h"
+#elif defined (CMSDK_CM7_DP) || defined (CMSDK_CM7_DP_VHT)
+  #include "CMSDK_CM7_DP.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM7_VHT || defined CMSDK_CM7_SP_VHT || defined CMSDK_CM7_DP_VHT
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler,                          /*  31 GPIO 0 individual interrupt ( 7) */
+  0,                                        /*  32 Reserved */
+  0,                                        /*  33 Reserved */
+  0,                                        /*  34 Reserved */
+  0,                                        /*  35 Reserved */
+  0,                                        /*  36 Reserved */
+  0,                                        /*  37 Reserved */
+  0,                                        /*  38 Reserved */
+  0,                                        /*  39 Reserved */
+  0,                                        /*  40 Reserved */
+  0,                                        /*  41 Reserved */
+  0,                                        /*  42 Reserved */
+  0,                                        /*  43 Reserved */
+  0,                                        /*  44 Reserved */
+  0,                                        /*  45 Reserved */
+  0,                                        /*  46 Reserved */
+  0,                                        /*  47 Reserved */
+  0,                                        /*  48 Reserved */
+  0,                                        /*  49 Reserved */
+  0,                                        /*  50 Reserved */
+  0,                                        /*  51 Reserved */
+  0,                                        /*  52 Reserved */
+  0,                                        /*  53 Reserved */
+  0,                                        /*  54 Reserved */
+  0,                                        /*  55 Reserved */
+  0,                                        /*  56 Reserved */
+  0,                                        /*  57 Reserved */
+  0,                                        /*  58 Reserved */
+  0,                                        /*  59 Reserved */
+  0,                                        /*  60 Reserved */
+  0,                                        /*  61 Reserved */
+  0,                                        /*  62 Reserved */
+  0,                                        /*  63 Reserved */
+  0,                                        /*  64 Reserved */
+  0,                                        /*  65 Reserved */
+  0,                                        /*  66 Reserved */
+  0,                                        /*  67 Reserved */
+  0,                                        /*  68 Reserved */
+  0,                                        /*  69 Reserved */
+  0,                                        /*  70 Reserved */
+  0,                                        /*  71 Reserved */
+  0,                                        /*  72 Reserved */
+  0,                                        /*  73 Reserved */
+  0,                                        /*  74 Reserved */
+  0,                                        /*  75 Reserved */
+  0,                                        /*  76 Reserved */
+  0,                                        /*  77 Reserved */
+  0,                                        /*  78 Reserved */
+  0,                                        /*  79 Reserved */
+  0,                                        /*  80 Reserved */
+  0,                                        /*  81 Reserved */
+  0,                                        /*  82 Reserved */
+  0,                                        /*  83 Reserved */
+  0,                                        /*  84 Reserved */
+  0,                                        /*  85 Reserved */
+  0,                                        /*  86 Reserved */
+  0,                                        /*  87 Reserved */
+  0,                                        /*  88 Reserved */
+  0,                                        /*  89 Reserved */
+  0,                                        /*  90 Reserved */
+  0,                                        /*  91 Reserved */
+  0,                                        /*  92 Reserved */
+  0,                                        /*  93 Reserved */
+  0,                                        /*  94 Reserved */
+  0,                                        /*  95 Reserved */
+  0,                                        /*  96 Reserved */
+  0,                                        /*  97 Reserved */
+  0,                                        /*  98 Reserved */
+  0,                                        /*  99 Reserved */
+  0,                                        /* 100 Reserved */
+  0,                                        /* 101 Reserved */
+  0,                                        /* 102 Reserved */
+  0,                                        /* 103 Reserved */
+  0,                                        /* 104 Reserved */
+  0,                                        /* 105 Reserved */
+  0,                                        /* 106 Reserved */
+  0,                                        /* 107 Reserved */
+  0,                                        /* 108 Reserved */
+  0,                                        /* 109 Reserved */
+  0,                                        /* 110 Reserved */
+  0,                                        /* 111 Reserved */
+  0,                                        /* 112 Reserved */
+  0,                                        /* 113 Reserved */
+  0,                                        /* 114 Reserved */
+  0,                                        /* 115 Reserved */
+  0,                                        /* 116 Reserved */
+  0,                                        /* 117 Reserved */
+  0,                                        /* 118 Reserved */
+  0,                                        /* 119 Reserved */
+  0,                                        /* 120 Reserved */
+  0,                                        /* 121 Reserved */
+  0,                                        /* 122 Reserved */
+  0,                                        /* 123 Reserved */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined CMSDK_CM7_VHT || defined CMSDK_CM7_SP_VHT || defined CMSDK_CM7_DP_VHT
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM7_SP_VHT_AC6/RTE/Device/CMSDK_CM7_SP_VHT/system_CMSDK_CM7.c
+++ b/Layer/Target/CM7_SP_VHT_AC6/RTE/Device/CMSDK_CM7_SP_VHT/system_CMSDK_CM7.c
@@ -1,0 +1,87 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM7.c
+ * @brief    CMSIS System Source File for CMSDK_CM7 Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM7)    || defined (CMSDK_CM7_VHT)
+  #include "CMSDK_CM7.h"
+#elif defined (CMSDK_CM7_SP) || defined (CMSDK_CM7_SP_VHT)
+  #include "CMSDK_CM7_SP.h"
+#elif defined (CMSDK_CM7_DP) || defined (CMSDK_CM7_DP_VHT)
+  #include "CMSDK_CM7_DP.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM7_SP_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM7_SP_VHT_AC6/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM7_SP_VHT_AC6/vht_config.txt
+++ b/Layer/Target/CM7_SP_VHT_AC6/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Layer/Target/CM7_SP_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
+++ b/Layer/Target/CM7_SP_VHT_GCC/RTE/CMSIS_RTOS2_Validation/RV2_Config_Device.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 ARM Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RV2_CONFIG_DEVICE_H__
+#define RV2_CONFIG_DEVICE_H__
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+/* Primary interrupt handler */
+#ifndef TST_IRQ_HANDLER_A
+#define TST_IRQ_HANDLER_A   TIMER0_Handler
+#endif
+#ifndef TST_IRQ_NUM_A
+#define TST_IRQ_NUM_A       8
+#endif
+
+/* Secondary interrupt handler */
+#ifndef TST_IRQ_HANDLER_B
+#define TST_IRQ_HANDLER_B   TIMER1_Handler
+#endif
+#ifndef TST_IRQ_NUM_B
+#define TST_IRQ_NUM_B       9
+#endif
+
+#endif /* RV2_CONFIG_DEVICE_H__ */

--- a/Layer/Target/CM7_SP_VHT_GCC/RTE/Device/CMSDK_CM7_SP_VHT/RTE_Device.h
+++ b/Layer/Target/CM7_SP_VHT_GCC/RTE/Device/CMSDK_CM7_SP_VHT/RTE_Device.h
@@ -1,0 +1,50 @@
+/* -----------------------------------------------------------------------------
+ * Copyright (c) 2016 ARM Ltd.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software. Permission is granted to anyone to use this
+ * software for any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * $Date:        25. April 2016
+ * $Revision:    V1.0.0
+ *
+ * Project:      RTE Device Configuration for ARM CMSDK_CM device
+ * -------------------------------------------------------------------------- */
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+#ifndef __RTE_DEVICE_H
+#define __RTE_DEVICE_H
+
+// <q> USART0 (Universal synchronous asynchronous receiver transmitter) [Driver_USART0]
+// <i> Configuration settings for Driver_USART0 in component ::CMSIS Driver:USART
+#define RTE_USART0                      1
+
+
+// <q> USART1 (Universal synchronous asynchronous receiver transmitter) [Driver_USART1]
+// <i> Configuration settings for Driver_USART1 in component ::CMSIS Driver:USART
+#define RTE_USART1                      0
+
+
+// <q> USART2 (Universal synchronous asynchronous receiver transmitter) [Driver_USART2]
+// <i> Configuration settings for Driver_USART2 in component ::CMSIS Driver:USART
+#define RTE_UART2                       0
+
+
+// <q> USART3 (Universal synchronous asynchronous receiver transmitter) [Driver_USART3]
+// <i> Configuration settings for Driver_USART3 in component ::CMSIS Driver:USART
+#define RTE_UART3                       0
+
+#endif  /* __RTE_DEVICE_H */

--- a/Layer/Target/CM7_SP_VHT_GCC/RTE/Device/CMSDK_CM7_SP_VHT/gcc_arm.ld
+++ b/Layer/Target/CM7_SP_VHT_GCC/RTE/Device/CMSDK_CM7_SP_VHT/gcc_arm.ld
@@ -1,0 +1,279 @@
+/******************************************************************************
+ * @file     gcc_arm.ld
+ * @brief    GNU Linker Script for Cortex-M based device
+ ******************************************************************************/
+
+/*
+; -------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+; <h> Flash Configuration
+;   <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+;   <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__ROM_BASE = 0x00000000;
+__ROM_SIZE = 0x00040000;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+; <h> RAM Configuration
+;   <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+;   <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+ -----------------------------------------------------------------------------*/
+__RAM_BASE = 0x20000000;
+__RAM_SIZE = 0x00020000;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+; <h> Stack / Heap Configuration
+;   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+;   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00000400;
+__HEAP_SIZE  = 0x00000C00;
+
+/*
+; -------------------- <<< end of configuration section >>> -------------------
+ */
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE, LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE, LENGTH = __RAM_SIZE
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+  /*
+   * SG veneers:
+   * All SG veneers are placed in the special output section .gnu.sgstubs. Its start address
+   * must be set, either with the command line option ‘--section-start’ or in a linker script,
+   * to indicate where to place these veneers in memory.
+   */
+/*
+  .gnu.sgstubs :
+  {
+    . = ALIGN(32);
+  } > FLASH
+*/
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__) / 4)
+    /* Add each additional bss section here */
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+    __zero_table_end__ = .;
+  } > FLASH
+
+  /**
+   * Location counter can end up 2byte aligned with narrow Thumb code but
+   * __etext is assumed by startup code to be the LMA of a section in RAM
+   * which must be 4byte aligned
+   */
+  __etext = ALIGN (4);
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  /*
+   * Secondary data section, optional
+   *
+   * Remember to add each additional data section
+   * to the .copy.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  __etext2 = ALIGN (4);
+
+  .data2 : AT (__etext2)
+  {
+    . = ALIGN(4);
+    __data2_start__ = .;
+    *(.data2)
+    *(.data2.*)
+    . = ALIGN(4);
+    __data2_end__ = .;
+
+  } > RAM2
+*/
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  /*
+   * Secondary bss section, optional
+   *
+   * Remember to add each additional bss section
+   * to the .zero.table above to asure proper
+   * initialization during startup.
+   */
+/*
+  .bss2 :
+  {
+    . = ALIGN(4);
+    __bss2_start__ = .;
+    *(.bss2)
+    *(.bss2.*)
+    . = ALIGN(4);
+    __bss2_end__ = .;
+  } > RAM2 AT > RAM2
+*/
+
+  .heap (COPY) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/Layer/Target/CM7_SP_VHT_GCC/RTE/Device/CMSDK_CM7_SP_VHT/startup_CMSDK_CM7.c
+++ b/Layer/Target/CM7_SP_VHT_GCC/RTE/Device/CMSDK_CM7_SP_VHT/startup_CMSDK_CM7.c
@@ -1,0 +1,425 @@
+/******************************************************************************
+ * @file     startup_CMSDK_CM7.c
+ * @brief    CMSIS Startup File for CMSDK_M7 Device
+ ******************************************************************************/
+/* Copyright (c) 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM7)    || defined (CMSDK_CM7_VHT)
+  #include "CMSDK_CM7.h"
+#elif defined (CMSDK_CM7_SP) || defined (CMSDK_CM7_SP_VHT)
+  #include "CMSDK_CM7_SP.h"
+#elif defined (CMSDK_CM7_DP) || defined (CMSDK_CM7_DP_VHT)
+  #include "CMSDK_CM7_DP.h"
+#else
+  #error device not specified!
+#endif
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler  (void);
+            void Default_Handler(void);
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+/* Exceptions */
+void NMI_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void HardFault_Handler      (void) __attribute__ ((weak));
+void MemManage_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void BusFault_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void UsageFault_Handler     (void) __attribute__ ((weak, alias("Default_Handler")));
+void SVC_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void DebugMon_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void SysTick_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+
+/* Interrupts */
+void UART0RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART0TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART1TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART2TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO1ALL_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER0_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void TIMER1_Handler         (void) __attribute__ ((weak, alias("Default_Handler")));
+void DUALTIMER_Handler      (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART_0_1_2_OVF_Handler (void) __attribute__ ((weak, alias("Default_Handler")));
+void ETHERNET_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void I2S_Handler            (void) __attribute__ ((weak, alias("Default_Handler")));
+void TOUCHSCREEN_Handler    (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO3_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART3TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4RX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void UART4TX_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_2_Handler          (void) __attribute__ ((weak, alias("Default_Handler")));
+void SPI_3_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_0_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_1_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_2_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_3_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_4_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_5_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_6_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+void GPIO0_7_Handler        (void) __attribute__ ((weak, alias("Default_Handler")));
+#if defined CMSDK_CM7_VHT || defined CMSDK_CM7_SP_VHT || defined CMSDK_CM7_DP_VHT
+void ARM_VSI0_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI1_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI2_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI3_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI4_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI5_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI6_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+void ARM_VSI7_Handler       (void) __attribute__ ((weak, alias("Default_Handler")));
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[256] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),       /*     Initial Stack Pointer */
+  Reset_Handler,                            /*     Reset Handler */
+  NMI_Handler,                              /* -14 NMI Handler */
+  HardFault_Handler,                        /* -13 Hard Fault Handler */
+  MemManage_Handler,                        /* -12 MPU Fault Handler */
+  BusFault_Handler,                         /* -11 Bus Fault Handler */
+  UsageFault_Handler,                       /* -10 Usage Fault Handler */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  0,                                        /*     Reserved */
+  SVC_Handler,                              /*  -5 SVC Handler */
+  DebugMon_Handler,                         /*  -4 Debug Monitor Handler */
+  0,                                        /*     Reserved */
+  PendSV_Handler,                           /*  -2 PendSV Handler */
+  SysTick_Handler,                          /*  -1 SysTick Handler */
+
+  /* Interrupts */
+  UART0RX_Handler,                          /*   0 UART 0 receive interrupt */
+  UART0TX_Handler,                          /*   1 UART 0 transmit interrupt */
+  UART1RX_Handler,                          /*   2 UART 1 receive interrupt */
+  UART1TX_Handler,                          /*   3 UART 1 transmit interrupt */
+  UART2RX_Handler,                          /*   4 UART 2 receive interrupt */
+  UART2TX_Handler,                          /*   5 UART 2 transmit interrupt */
+  GPIO0ALL_Handler,                         /*   6 GPIO 0 combined interrupt */
+  GPIO1ALL_Handler,                         /*   7 GPIO 1 combined interrupt */
+  TIMER0_Handler,                           /*   8 Timer 0 interrupt */
+  TIMER1_Handler,                           /*   9 Timer 1 interrupt */
+  DUALTIMER_Handler,                        /*  10 Dual Timer interrupt */
+  SPI_0_1_Handler,                          /*  11 SPI 0, SPI 1 interrupt */
+  UART_0_1_2_OVF_Handler,                   /*  12 UART overflow (0, 1 & 2) interrupt */
+  ETHERNET_Handler,                         /*  13 Ethernet interrupt */
+  I2S_Handler,                              /*  14 Audio I2S interrupt */
+  TOUCHSCREEN_Handler,                      /*  15 Touch Screen interrupt */
+  GPIO2_Handler,                            /*  16 GPIO 2 combined interrupt */
+  GPIO3_Handler,                            /*  17 GPIO 3 combined interrupt */
+  UART3RX_Handler,                          /*  18 UART 3 receive interrupt */
+  UART3TX_Handler,                          /*  19 UART 3 transmit interrupt */
+  UART4RX_Handler,                          /*  20 UART 4 receive interrupt */
+  UART4TX_Handler,                          /*  21 UART 4 transmit interrupt */
+  SPI_2_Handler,                            /*  22 SPI 2 interrupt */
+  SPI_3_4_Handler,                          /*  23 SPI 3, SPI 4 interrupt */
+  GPIO0_0_Handler,                          /*  24 GPIO 0 individual interrupt ( 0) */
+  GPIO0_1_Handler,                          /*  25 GPIO 0 individual interrupt ( 1) */
+  GPIO0_2_Handler,                          /*  26 GPIO 0 individual interrupt ( 2) */
+  GPIO0_3_Handler,                          /*  27 GPIO 0 individual interrupt ( 3) */
+  GPIO0_4_Handler,                          /*  28 GPIO 0 individual interrupt ( 4) */
+  GPIO0_5_Handler,                          /*  29 GPIO 0 individual interrupt ( 5) */
+  GPIO0_6_Handler,                          /*  30 GPIO 0 individual interrupt ( 6) */
+  GPIO0_7_Handler,                          /*  31 GPIO 0 individual interrupt ( 7) */
+  0,                                        /*  32 Reserved */
+  0,                                        /*  33 Reserved */
+  0,                                        /*  34 Reserved */
+  0,                                        /*  35 Reserved */
+  0,                                        /*  36 Reserved */
+  0,                                        /*  37 Reserved */
+  0,                                        /*  38 Reserved */
+  0,                                        /*  39 Reserved */
+  0,                                        /*  40 Reserved */
+  0,                                        /*  41 Reserved */
+  0,                                        /*  42 Reserved */
+  0,                                        /*  43 Reserved */
+  0,                                        /*  44 Reserved */
+  0,                                        /*  45 Reserved */
+  0,                                        /*  46 Reserved */
+  0,                                        /*  47 Reserved */
+  0,                                        /*  48 Reserved */
+  0,                                        /*  49 Reserved */
+  0,                                        /*  50 Reserved */
+  0,                                        /*  51 Reserved */
+  0,                                        /*  52 Reserved */
+  0,                                        /*  53 Reserved */
+  0,                                        /*  54 Reserved */
+  0,                                        /*  55 Reserved */
+  0,                                        /*  56 Reserved */
+  0,                                        /*  57 Reserved */
+  0,                                        /*  58 Reserved */
+  0,                                        /*  59 Reserved */
+  0,                                        /*  60 Reserved */
+  0,                                        /*  61 Reserved */
+  0,                                        /*  62 Reserved */
+  0,                                        /*  63 Reserved */
+  0,                                        /*  64 Reserved */
+  0,                                        /*  65 Reserved */
+  0,                                        /*  66 Reserved */
+  0,                                        /*  67 Reserved */
+  0,                                        /*  68 Reserved */
+  0,                                        /*  69 Reserved */
+  0,                                        /*  70 Reserved */
+  0,                                        /*  71 Reserved */
+  0,                                        /*  72 Reserved */
+  0,                                        /*  73 Reserved */
+  0,                                        /*  74 Reserved */
+  0,                                        /*  75 Reserved */
+  0,                                        /*  76 Reserved */
+  0,                                        /*  77 Reserved */
+  0,                                        /*  78 Reserved */
+  0,                                        /*  79 Reserved */
+  0,                                        /*  80 Reserved */
+  0,                                        /*  81 Reserved */
+  0,                                        /*  82 Reserved */
+  0,                                        /*  83 Reserved */
+  0,                                        /*  84 Reserved */
+  0,                                        /*  85 Reserved */
+  0,                                        /*  86 Reserved */
+  0,                                        /*  87 Reserved */
+  0,                                        /*  88 Reserved */
+  0,                                        /*  89 Reserved */
+  0,                                        /*  90 Reserved */
+  0,                                        /*  91 Reserved */
+  0,                                        /*  92 Reserved */
+  0,                                        /*  93 Reserved */
+  0,                                        /*  94 Reserved */
+  0,                                        /*  95 Reserved */
+  0,                                        /*  96 Reserved */
+  0,                                        /*  97 Reserved */
+  0,                                        /*  98 Reserved */
+  0,                                        /*  99 Reserved */
+  0,                                        /* 100 Reserved */
+  0,                                        /* 101 Reserved */
+  0,                                        /* 102 Reserved */
+  0,                                        /* 103 Reserved */
+  0,                                        /* 104 Reserved */
+  0,                                        /* 105 Reserved */
+  0,                                        /* 106 Reserved */
+  0,                                        /* 107 Reserved */
+  0,                                        /* 108 Reserved */
+  0,                                        /* 109 Reserved */
+  0,                                        /* 110 Reserved */
+  0,                                        /* 111 Reserved */
+  0,                                        /* 112 Reserved */
+  0,                                        /* 113 Reserved */
+  0,                                        /* 114 Reserved */
+  0,                                        /* 115 Reserved */
+  0,                                        /* 116 Reserved */
+  0,                                        /* 117 Reserved */
+  0,                                        /* 118 Reserved */
+  0,                                        /* 119 Reserved */
+  0,                                        /* 120 Reserved */
+  0,                                        /* 121 Reserved */
+  0,                                        /* 122 Reserved */
+  0,                                        /* 123 Reserved */
+  0,                                        /* 124 Reserved */
+  0,                                        /* 125 Reserved */
+  0,                                        /* 126 Reserved */
+  0,                                        /* 127 Reserved */
+  0,                                        /* 128 Reserved */
+  0,                                        /* 129 Reserved */
+  0,                                        /* 130 Reserved */
+  0,                                        /* 131 Reserved */
+  0,                                        /* 132 Reserved */
+  0,                                        /* 133 Reserved */
+  0,                                        /* 134 Reserved */
+  0,                                        /* 135 Reserved */
+  0,                                        /* 136 Reserved */
+  0,                                        /* 137 Reserved */
+  0,                                        /* 138 Reserved */
+  0,                                        /* 139 Reserved */
+  0,                                        /* 140 Reserved */
+  0,                                        /* 141 Reserved */
+  0,                                        /* 142 Reserved */
+  0,                                        /* 143 Reserved */
+  0,                                        /* 144 Reserved */
+  0,                                        /* 145 Reserved */
+  0,                                        /* 146 Reserved */
+  0,                                        /* 147 Reserved */
+  0,                                        /* 148 Reserved */
+  0,                                        /* 149 Reserved */
+  0,                                        /* 150 Reserved */
+  0,                                        /* 151 Reserved */
+  0,                                        /* 152 Reserved */
+  0,                                        /* 153 Reserved */
+  0,                                        /* 154 Reserved */
+  0,                                        /* 155 Reserved */
+  0,                                        /* 156 Reserved */
+  0,                                        /* 157 Reserved */
+  0,                                        /* 158 Reserved */
+  0,                                        /* 159 Reserved */
+  0,                                        /* 160 Reserved */
+  0,                                        /* 161 Reserved */
+  0,                                        /* 162 Reserved */
+  0,                                        /* 163 Reserved */
+  0,                                        /* 164 Reserved */
+  0,                                        /* 165 Reserved */
+  0,                                        /* 166 Reserved */
+  0,                                        /* 167 Reserved */
+  0,                                        /* 168 Reserved */
+  0,                                        /* 169 Reserved */
+  0,                                        /* 170 Reserved */
+  0,                                        /* 171 Reserved */
+  0,                                        /* 172 Reserved */
+  0,                                        /* 173 Reserved */
+  0,                                        /* 174 Reserved */
+  0,                                        /* 175 Reserved */
+  0,                                        /* 176 Reserved */
+  0,                                        /* 177 Reserved */
+  0,                                        /* 178 Reserved */
+  0,                                        /* 179 Reserved */
+  0,                                        /* 180 Reserved */
+  0,                                        /* 181 Reserved */
+  0,                                        /* 182 Reserved */
+  0,                                        /* 183 Reserved */
+  0,                                        /* 184 Reserved */
+  0,                                        /* 185 Reserved */
+  0,                                        /* 186 Reserved */
+  0,                                        /* 187 Reserved */
+  0,                                        /* 188 Reserved */
+  0,                                        /* 189 Reserved */
+  0,                                        /* 190 Reserved */
+  0,                                        /* 191 Reserved */
+  0,                                        /* 192 Reserved */
+  0,                                        /* 193 Reserved */
+  0,                                        /* 194 Reserved */
+  0,                                        /* 195 Reserved */
+  0,                                        /* 196 Reserved */
+  0,                                        /* 197 Reserved */
+  0,                                        /* 198 Reserved */
+  0,                                        /* 199 Reserved */
+  0,                                        /* 200 Reserved */
+  0,                                        /* 201 Reserved */
+  0,                                        /* 202 Reserved */
+  0,                                        /* 203 Reserved */
+  0,                                        /* 204 Reserved */
+  0,                                        /* 205 Reserved */
+  0,                                        /* 206 Reserved */
+  0,                                        /* 207 Reserved */
+  0,                                        /* 208 Reserved */
+  0,                                        /* 209 Reserved */
+  0,                                        /* 210 Reserved */
+  0,                                        /* 211 Reserved */
+  0,                                        /* 212 Reserved */
+  0,                                        /* 213 Reserved */
+  0,                                        /* 214 Reserved */
+  0,                                        /* 215 Reserved */
+  0,                                        /* 216 Reserved */
+  0,                                        /* 217 Reserved */
+  0,                                        /* 218 Reserved */
+  0,                                        /* 219 Reserved */
+  0,                                        /* 220 Reserved */
+  0,                                        /* 221 Reserved */
+  0,                                        /* 222 Reserved */
+  0,                                        /* 223 Reserved */
+#if defined CMSDK_CM7_VHT || defined CMSDK_CM7_SP_VHT || defined CMSDK_CM7_DP_VHT
+  ARM_VSI0_Handler,                         /* 224 VSI 0 interrupt */
+  ARM_VSI1_Handler,                         /* 225 VSI 1 interrupt */
+  ARM_VSI2_Handler,                         /* 226 VSI 2 interrupt */
+  ARM_VSI3_Handler,                         /* 227 VSI 3 interrupt */
+  ARM_VSI4_Handler,                         /* 228 VSI 4 interrupt */
+  ARM_VSI5_Handler,                         /* 229 VSI 5 interrupt */
+  ARM_VSI6_Handler,                         /* 230 VSI 6 interrupt */
+  ARM_VSI7_Handler                          /* 231 VSI 7 interrupt */
+#else
+  0,                                        /* 224 Reserved */
+  0,                                        /* 225 Reserved */
+  0,                                        /* 226 Reserved */
+  0,                                        /* 227 Reserved */
+  0,                                        /* 228 Reserved */
+  0,                                        /* 229 Reserved */
+  0,                                        /* 230 Reserved */
+  0                                         /* 231 Reserved */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+__NO_RETURN void Reset_Handler(void)
+{
+  SystemInit();                             /* CMSIS System Initialization */
+  __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
+
+/*----------------------------------------------------------------------------
+  Hard Fault Handler
+ *----------------------------------------------------------------------------*/
+void HardFault_Handler(void)
+{
+  while(1);
+}
+
+/*----------------------------------------------------------------------------
+  Default Handler for Exceptions / Interrupts
+ *----------------------------------------------------------------------------*/
+void Default_Handler(void)
+{
+  while(1);
+}
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#endif

--- a/Layer/Target/CM7_SP_VHT_GCC/RTE/Device/CMSDK_CM7_SP_VHT/system_CMSDK_CM7.c
+++ b/Layer/Target/CM7_SP_VHT_GCC/RTE/Device/CMSDK_CM7_SP_VHT/system_CMSDK_CM7.c
@@ -1,0 +1,87 @@
+/******************************************************************************
+ * @file     system_CMSDK_CM7.c
+ * @brief    CMSIS System Source File for CMSDK_CM7 Device
+ ******************************************************************************/
+/* Copyright (c) 2011 - 2022 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+#if   defined (CMSDK_CM7)    || defined (CMSDK_CM7_VHT)
+  #include "CMSDK_CM7.h"
+#elif defined (CMSDK_CM7_SP) || defined (CMSDK_CM7_SP_VHT)
+  #include "CMSDK_CM7_SP.h"
+#elif defined (CMSDK_CM7_DP) || defined (CMSDK_CM7_DP_VHT)
+  #include "CMSDK_CM7_DP.h"
+#else
+  #error device not specified!
+#endif
+
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define  XTAL            (50000000UL)     /* Oscillator frequency */
+
+#define  SYSTEM_CLOCK    (XTAL / 2U)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[256];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;  /* System Core Clock Frequency */
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+  SystemCoreClock = SYSTEM_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  SCB->VTOR = (uint32_t) &(__VECTOR_TABLE[0]);
+#endif
+
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                 (3U << 11U*2U)  );         /* enable CP11 Full Access */
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+  SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+  SystemCoreClock = SYSTEM_CLOCK;
+}

--- a/Layer/Target/CM7_SP_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM7_SP_VHT_GCC/Target.clayer.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.1/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+  # type: Target
+  description: Target setup
+
+  # packs:
+  #   - pack: ARM::CMSIS
+  #   - pack: Keil::V2M-MPS2_CMx_BSP
+
+  components:
+    # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
+    - component: ARM::CMSIS:CORE
+    - component: Device:Startup&C Startup
+
+    - component: Keil::Board Support&V2M-MPS2:Common
+    - component: Keil::CMSIS Driver:USART
+
+  groups:
+    - group: VHT
+      files:
+        - file: ./vht_config.txt

--- a/Layer/Target/CM7_SP_VHT_GCC/vht_config.txt
+++ b/Layer/Target/CM7_SP_VHT_GCC/vht_config.txt
@@ -1,0 +1,8 @@
+# Parameters:
+# instance.parameter=value       #(type, mode) default = 'def value' : description : [min..max]
+#------------------------------------------------------------------------------
+fvp_mps2.UART0.out_file=-                             # (string, init-time) default = ''       : Output file to hold data written by the UART (use '-' to send all output to stdout)
+fvp_mps2.UART0.shutdown_on_eot=1                      # (bool  , init-time) default = '0'      : Shutdown simulation when a EOT (ASCII 4) char is transmitted (useful for regression tests when semihosting is not available)
+fvp_mps2.UART0.unbuffered_output=1                    # (bool  , init-time) default = '0'      : Unbuffered output
+fvp_mps2.mps2_visualisation.disable-visualisation=1   # (bool  , init-time) default = '0'      : Enable/disable visualisation
+#------------------------------------------------------------------------------

--- a/Project/Validation.cproject.yml
+++ b/Project/Validation.cproject.yml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.2/tools/projmgr/schemas/cproject.schema.json
+
+project:
+  layers:
+    # App: CMSIS-RTOS2 Validation for RTX5
+    - layer: ../Layer/App/Validation_RTX5/App.clayer.yml
+      for-type:
+        - .RTX5_AC6
+        - .RTX5_GCC
+    # App: CMSIS-RTOS2 Validation for FreeRTOS
+    - layer: ../Layer/App/Validation_FreeRTOS/App.clayer.yml
+      for-type:
+        - .FreeRTOS_AC6
+        - .FreeRTOS_GCC
+
+    #Target: CM0plus
+    - layer: ../Layer/Target/CM0plus_VHT_AC6/Target.clayer.yml
+      for-type:
+        - .RTX5_AC6+CM0plus
+        - .FreeRTOS_AC6+CM0plus
+    - layer: ../Layer/Target/CM0plus_VHT_GCC/Target.clayer.yml
+      for-type:
+        - .RTX5_GCC+CM0plus
+        - .FreeRTOS_GCC+CM0plus
+
+    #Target: CM3
+    - layer: ../Layer/Target/CM3_VHT_AC6/Target.clayer.yml
+      for-type:
+        - .RTX5_AC6+CM3
+        - .FreeRTOS_AC6+CM3
+    - layer: ../Layer/Target/CM3_VHT_GCC/Target.clayer.yml
+      for-type:
+        - .RTX5_GCC+CM3
+        - .FreeRTOS_GCC+CM3
+
+    #Target: CM4_FP
+    - layer: ../Layer/Target/CM4_FP_VHT_AC6/Target.clayer.yml
+      for-type:
+        - .RTX5_AC6+CM4_FP
+        - .FreeRTOS_AC6+CM4_FP
+    - layer: ../Layer/Target/CM4_FP_VHT_GCC/Target.clayer.yml
+      for-type:
+        - .RTX5_GCC+CM4_FP
+        - .FreeRTOS_GCC+CM4_FP
+
+    #Target: CM7_DP
+    - layer: ../Layer/Target/CM7_DP_VHT_AC6/Target.clayer.yml
+      for-type:
+        - .RTX5_AC6+CM7_DP
+        - .FreeRTOS_AC6+CM7_DP
+    - layer: ../Layer/Target/CM7_DP_VHT_GCC/Target.clayer.yml
+      for-type:
+        - .RTX5_GCC+CM7_DP
+        - .FreeRTOS_GCC+CM7_DP
+
+    #Target: CM7_SP
+    - layer: ../Layer/Target/CM7_SP_VHT_AC6/Target.clayer.yml
+      for-type:
+        - .RTX5_AC6+CM7_SP
+        - .FreeRTOS_AC6+CM7_SP
+    - layer: ../Layer/Target/CM7_SP_VHT_GCC/Target.clayer.yml
+      for-type:
+        - .RTX5_GCC+CM7_SP
+        - .FreeRTOS_GCC+CM7_SP
+
+    #Target: CM23
+    - layer: ../Layer/Target/CM23_VHT_AC6/Target.clayer.yml
+      for-type:
+        - .RTX5_AC6+CM23
+        - .FreeRTOS_AC6+CM23
+    - layer: ../Layer/Target/CM23_VHT_GCC/Target.clayer.yml
+      for-type:
+        - .RTX5_GCC+CM23
+        - .FreeRTOS_GCC+CM23
+
+    #Target: CM33_FP
+    - layer: ../Layer/Target/CM33_FP_VHT_AC6/Target.clayer.yml
+      for-type:
+        - .RTX5_AC6+CM33_FP
+        - .FreeRTOS_AC6+CM33_FP
+    - layer: ../Layer/Target/CM33_FP_VHT_GCC/Target.clayer.yml
+      for-type:
+        - .RTX5_GCC+CM33_FP
+        - .FreeRTOS_GCC+CM33_FP
+
+    #Target: CM55
+    - layer: ../Layer/Target/CM55_VHT_AC6/Target.clayer.yml
+      for-type:
+        - .RTX5_AC6+CM55
+        - .FreeRTOS_AC6+CM55

--- a/Project/Validation.csolution.yml
+++ b/Project/Validation.csolution.yml
@@ -1,6 +1,27 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.2/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  packs:
+    - pack: ARM::CMSIS
+    - pack: Keil::V2M-MPS2_CMx_BSP@1.8.0
+      for-type: 
+       - +CM0plus
+       - +CM3
+       - +CM4_FP
+       - +CM7_DP
+       - +CM7_SP
+    - pack: Keil::V2M-MPS2_IOTKit_BSP@1.5.0
+      for-type: 
+       - +CM23
+       - +CM33_FP
+    - pack: ARM::V2M_MPS3_SSE_300_BSP@1.2.0
+      for-type: 
+       - +CM55    
+    - pack: ARM::CMSIS-FreeRTOS
+      for-type: 
+       - .FreeRTOS_AC6
+       - .FreeRTOS_GCC
+
   target-types:
     #CM0plus
     - type: CM0plus

--- a/Project/Validation.csolution.yml
+++ b/Project/Validation.csolution.yml
@@ -1,0 +1,109 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.2/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  target-types:
+    #CM0plus
+    - type: CM0plus
+      device: CMSDK_CM0plus_VHT
+    #CM3
+    - type: CM3
+      device: CMSDK_CM3_VHT
+    #CM4_FP
+    - type: CM4_FP
+      device: CMSDK_CM4_FP_VHT
+      misc:
+        - compiler: AC6
+          C: [-mfloat-abi=hard, -mfpu=fpv4-sp-d16]
+          ASM: [-mfloat-abi=hard, -mfpu=fpv4-sp-d16]
+
+        - compiler: GCC
+          C: [-mfloat-abi=hard, -mfpu=auto]
+          ASM: [-mfloat-abi=hard, -mfpu=auto]
+          Link: [-mfloat-abi=hard]
+    #CM7_DP
+    - type: CM7_DP
+      device: CMSDK_CM7_DP_VHT
+      misc:
+        - compiler: AC6
+          C: [-mfloat-abi=hard, -mfpu=fpv5-d16]
+          ASM: [-mfloat-abi=hard, -mfpu=fpv5-d16]
+
+        - compiler: GCC
+          C: [-mfloat-abi=hard, -mfpu=auto]
+          ASM: [-mfloat-abi=hard, -mfpu=auto]
+          Link: [-mfloat-abi=hard]
+    #CM7_SP
+    - type: CM7_SP
+      device: CMSDK_CM7_SP_VHT
+      misc:
+        - compiler: AC6
+          C: [-mfloat-abi=hard, -mfpu=fpv5-sp-d16]
+          ASM: [-mfloat-abi=hard, -mfpu=fpv5-sp-d16]
+        
+        - compiler: GCC
+          C: [-mfloat-abi=hard, -mfpu=auto]
+          ASM: [-mfloat-abi=hard, -mfpu=auto]
+          Link: [-mfloat-abi=hard]
+    #CM23
+    - type: CM23
+      device: IOTKit_CM23_VHT
+      defines:
+        - configENABLE_FPU=0
+      misc:
+        - compiler: AC6
+          C: [-mcmse]
+          ASM: [-mcmse]
+
+        - compiler: GCC
+          C: [-mfloat-abi=soft, -mfpu=auto]
+          ASM: [-mfloat-abi=soft, -mfpu=auto]
+          Link: [-mfloat-abi=soft]
+    #CM33_FP
+    - type: CM33_FP
+      device: IOTKit_CM33_FP_VHT
+      misc:
+        - compiler: AC6
+          C: [-mfloat-abi=hard, -mfpu=fpv5-sp-d16, -mcmse]
+          ASM: [-mfloat-abi=hard, -mfpu=fpv5-sp-d16, -mcmse]
+
+        - compiler: GCC
+          C: [-mfloat-abi=hard, -mfpu=auto]
+          ASM: [-mfloat-abi=hard, -mfpu=auto]
+          Link: [-mfloat-abi=hard]
+    #CM55
+    - type: CM55
+      device: SSE-300-MPS3
+      misc:
+        - compiler: AC6
+          C: [-mfloat-abi=hard, -mcmse]
+          ASM: [-mfloat-abi=hard, -mcmse]
+
+  build-types:
+    - type: RTX5_AC6
+      compiler: AC6
+      misc:
+        - compiler: AC6  
+          C: [-O1, -std=c99, -gdwarf-4, -ffunction-sections]
+
+    - type: RTX5_GCC
+      compiler: GCC
+      misc:
+        - compiler: GCC
+          C: [-O1, -std=gnu99, -mapcs-frame, -mthumb-interwork]
+          Link: [-nostartfiles, -lm, -specs=nano.specs, --entry=Reset_Handler]
+
+    - type: FreeRTOS_AC6
+      compiler: AC6
+      misc:
+        - compiler: AC6  
+          C: [-O1, -std=c99, -gdwarf-4, -ffunction-sections]
+
+    - type: FreeRTOS_GCC
+      compiler: GCC
+      misc:
+        - compiler: GCC
+          C: [-O1, -std=gnu99, -mapcs-frame, -mthumb-interwork, -masm-syntax-unified]
+          Link: [-nostartfiles, -lm, -specs=nano.specs, --entry=Reset_Handler]
+
+  projects:
+    - project: ./Validation.cproject.yml


### PR DESCRIPTION
- Validation project is split into App and Target layers
- App layer is provided for RTX5 and CMSIS-FreeRTOS
- Target layers are provided for Cortex-M0plus, M3, M4_FP, M7_SP/DP, M23, M33 and M55
- Layers can be build with Arm Compiler 6 and GCC (except for M55 layer, GCC is currently unsupported)