### PR TITLE
Sync-up layers relative path references with csolution 0.9.4

### DIFF
--- a/Layer/App/Validation_FreeRTOS/App.clayer.yml
+++ b/Layer/App/Validation_FreeRTOS/App.clayer.yml
@@ -13,8 +13,7 @@ layer:
     - PRINT_XML_REPORT=1
   
   add-paths:
-    - ../../Include
-    - ./RTE/CMSIS_RTOS2_Validation
+    - ../../../Include
 
   misc:
     - C*:
@@ -36,7 +35,7 @@ layer:
   groups:
     - group: Documentation
       files:
-        - file: ../../README.md
+        - file: ../../../README.md
 
     - group: Source files
       files:
@@ -45,22 +44,22 @@ layer:
 
     - group: CMSIS-RTOS2_Validation
       files:
-        - file: ../../Source/cmsis_rv2.c
-        - file: ../../Source/RV2_Kernel.c
-        - file: ../../Source/RV2_Thread.c
-        - file: ../../Source/RV2_ThreadFlags.c
-        - file: ../../Source/RV2_GenWait.c
-        - file: ../../Source/RV2_Timer.c
-        - file: ../../Source/RV2_EventFlags.c
-        - file: ../../Source/RV2_Mutex.c
-        - file: ../../Source/RV2_Semaphore.c
-        - file: ../../Source/RV2_MemoryPool.c
-        - file: ../../Source/RV2_MessageQueue.c
-        - file: ../../Source/RV2_Common.c
+        - file: ../../../Source/cmsis_rv2.c
+        - file: ../../../Source/RV2_Kernel.c
+        - file: ../../../Source/RV2_Thread.c
+        - file: ../../../Source/RV2_ThreadFlags.c
+        - file: ../../../Source/RV2_GenWait.c
+        - file: ../../../Source/RV2_Timer.c
+        - file: ../../../Source/RV2_EventFlags.c
+        - file: ../../../Source/RV2_Mutex.c
+        - file: ../../../Source/RV2_Semaphore.c
+        - file: ../../../Source/RV2_MemoryPool.c
+        - file: ../../../Source/RV2_MessageQueue.c
+        - file: ../../../Source/RV2_Common.c
         - file: ./RTE/CMSIS_RTOS2_Validation/RV2_Config.c
         - file: ./RTE/CMSIS_RTOS2_Validation/RV2_Config.h
-    
+
     - group: Validation Framework
       files:
-        - file: ../../Source/tf_main.c
-        - file: ../../Source/tf_report.c
+        - file: ../../../Source/tf_main.c
+        - file: ../../../Source/tf_report.c

--- a/Layer/App/Validation_RTX5/App.clayer.yml
+++ b/Layer/App/Validation_RTX5/App.clayer.yml
@@ -13,8 +13,7 @@ layer:
     - PRINT_XML_REPORT=1
   
   add-paths:
-    - ../../Include
-    - ./RTE/CMSIS_RTOS2_Validation
+    - ../../../Include
 
   misc:
     - C*:
@@ -29,7 +28,7 @@ layer:
   groups:
     - group: Documentation
       files:
-        - file: ../../README.md
+        - file: ../../../README.md
 
     - group: Source files
       files:
@@ -38,22 +37,22 @@ layer:
 
     - group: CMSIS-RTOS2_Validation
       files:
-        - file: ../../Source/cmsis_rv2.c
-        - file: ../../Source/RV2_Kernel.c
-        - file: ../../Source/RV2_Thread.c
-        - file: ../../Source/RV2_ThreadFlags.c
-        - file: ../../Source/RV2_GenWait.c
-        - file: ../../Source/RV2_Timer.c
-        - file: ../../Source/RV2_EventFlags.c
-        - file: ../../Source/RV2_Mutex.c
-        - file: ../../Source/RV2_Semaphore.c
-        - file: ../../Source/RV2_MemoryPool.c
-        - file: ../../Source/RV2_MessageQueue.c
-        - file: ../../Source/RV2_Common.c
+        - file: ../../../Source/cmsis_rv2.c
+        - file: ../../../Source/RV2_Kernel.c
+        - file: ../../../Source/RV2_Thread.c
+        - file: ../../../Source/RV2_ThreadFlags.c
+        - file: ../../../Source/RV2_GenWait.c
+        - file: ../../../Source/RV2_Timer.c
+        - file: ../../../Source/RV2_EventFlags.c
+        - file: ../../../Source/RV2_Mutex.c
+        - file: ../../../Source/RV2_Semaphore.c
+        - file: ../../../Source/RV2_MemoryPool.c
+        - file: ../../../Source/RV2_MessageQueue.c
+        - file: ../../../Source/RV2_Common.c
         - file: ./RTE/CMSIS_RTOS2_Validation/RV2_Config.c
         - file: ./RTE/CMSIS_RTOS2_Validation/RV2_Config.h
-    
+
     - group: Validation Framework
       files:
-        - file: ../../Source/tf_main.c
-        - file: ../../Source/tf_report.c
+        - file: ../../../Source/tf_main.c
+        - file: ../../../Source/tf_report.c

--- a/Layer/Target/CM0plus_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM0plus_VHT_AC6/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM0plus_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM0plus_VHT_GCC/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM23_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM23_VHT_AC6/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM23_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM23_VHT_GCC/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM33_FP_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM33_FP_VHT_AC6/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM33_FP_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM33_FP_VHT_GCC/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM3_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM3_VHT_AC6/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM3_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM3_VHT_GCC/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM4_FP_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM4_FP_VHT_AC6/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM4_FP_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM4_FP_VHT_GCC/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM55_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM55_VHT_AC6/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: ARM::V2M_MPS3_SSE_300_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM7_DP_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM7_DP_VHT_AC6/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM7_DP_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM7_DP_VHT_GCC/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM7_SP_VHT_AC6/Target.clayer.yml
+++ b/Layer/Target/CM7_SP_VHT_AC6/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Layer/Target/CM7_SP_VHT_GCC/Target.clayer.yml
+++ b/Layer/Target/CM7_SP_VHT_GCC/Target.clayer.yml
@@ -8,6 +8,9 @@ layer:
   #   - pack: ARM::CMSIS
   #   - pack: Keil::V2M-MPS2_CMx_BSP
 
+  add-paths:
+    - ./RTE/CMSIS_RTOS2_Validation
+
   components:
     # [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]
     - component: ARM::CMSIS:CORE

--- a/Project/avh.yml
+++ b/Project/avh.yml
@@ -15,7 +15,7 @@ upload:
   - Source/**/*
 steps:
   - run: |
-      wget https://github.com/Open-CMSIS-Pack/devtools/releases/download/tools%2Ftoolbox%2F0.9.3/cmsis-toolbox.sh
+      wget https://github.com/Open-CMSIS-Pack/devtools/releases/download/tools%2Ftoolbox%2F0.10.0/cmsis-toolbox.sh
       chmod +x cmsis-toolbox.sh
       sudo ./cmsis-toolbox.sh <<EOI
       /opt/cbuild

--- a/Project/build.py
+++ b/Project/build.py
@@ -72,11 +72,16 @@ def project_name(config):
 
 def output_dir(config):
     return f"{project_name(config)}_OutDir"
+    
+
+def vht_config(config):
+    return f"../Layer/Target/{config.device[1]}_VHT_{config.compiler}/vht_config.txt"
+    
 
 @matrix_action
 def clean(config):
     """Build the selected configurations using CMSIS-Build."""
-    yield rmdir(f"{project_name(config)}/{output_dir(config)}")
+    yield cbuild_clean(f"{project_name(config)}/{project_name(config)}.cprj")
 
 
 @matrix_action
@@ -84,7 +89,7 @@ def build(config, results):
     """Build the selected configurations using CMSIS-Build."""
 
     logging.info("Compiling Tests...")
-    yield cbuildsh(f"{project_name(config)}/{project_name(config)}.cprj")
+    yield cbuild(f"{project_name(config)}/{project_name(config)}.cprj")
 
     if not all(r.success for r in results):
         return
@@ -120,9 +125,9 @@ def run(config, results):
 
 
 @matrix_command()
-def rmdir(dir):
-    return ["bash", "-c", f"rm -rf {dir}"]
-
+def cbuild_clean(project):
+    return ["cbuild", "-c", project]
+    
 
 @matrix_command()
 def unzip(archive):
@@ -130,8 +135,8 @@ def unzip(archive):
 
 
 @matrix_command()
-def cbuildsh(project):
-    return ["bash", "-c", f"cbuild.sh {project}"]
+def cbuild(project):
+    return ["cbuild", project]
 
 
 @matrix_command(test_report=ConsoleReport() |
@@ -143,7 +148,7 @@ def cbuildsh(project):
                                                                     f"{result.command.config.rtxcfg}."
                                                                     f"{title}"))
 def avhrun(config):
-    cmdline = [AVH_EXECUTABLE[config.device][0], "-q", "--simlimit", 10, "-f", f"{project_name(config)}/vht_config.txt"]
+    cmdline = [AVH_EXECUTABLE[config.device][0], "-q", "--simlimit", 10, "-f", vht_config(config)]
     cmdline += AVH_EXECUTABLE[config.device][1]
     cmdline += ["-a", f"{project_name(config)}/{output_dir(config)}/{project_name(config)}.{config.compiler.image_ext}"]
     return cmdline

--- a/Project/build.py
+++ b/Project/build.py
@@ -148,7 +148,7 @@ def cbuild(project):
                                                                     f"{result.command.config.rtxcfg}."
                                                                     f"{title}"))
 def avhrun(config):
-    cmdline = [AVH_EXECUTABLE[config.device][0], "-q", "--simlimit", 10, "-f", vht_config(config)]
+    cmdline = [AVH_EXECUTABLE[config.device][0], "-q", "--simlimit", 100, "-f", vht_config(config)]
     cmdline += AVH_EXECUTABLE[config.device][1]
     cmdline += ["-a", f"{project_name(config)}/{output_dir(config)}/{project_name(config)}.{config.compiler.image_ext}"]
     return cmdline


### PR DESCRIPTION
Starting with `csolution 0.9.4` (distributed in [CMSIS-Toolbox 0.10.0](https://github.com/Open-CMSIS-Pack/devtools/releases/tag/tools/toolbox/0.10.0)) the source files and include paths referenced in `.clayer.yml` will appear in the generated CPRJ relative to the `.clayer.yml` itself, and **not** relative to the `.cproject.yml` as it was in previous versions. For this reason when updating the `csolution` version in the infrastructure I would recommend to apply the changes suggested in this PR.