### PR TITLE
Add compilation guards for unused functions

### DIFF
--- a/Doxygen/CMSIS-RTOS2_Validation.txt
+++ b/Doxygen/CMSIS-RTOS2_Validation.txt
@@ -54,7 +54,7 @@ Validation project can be configured in \c RV2_Config.h header file. It can be o
 \page test_results Reading Test Results
 
 The CMSIS-RTOS2 Validation framework outputs the test results as plain text or as an XML formatted report. Alternatively, it
-is possible to examine the results in the \b test_report buffer structure which is accessible through the \b Watch window.
+is possible to examine the results in the \b TestReport buffer structure which is accessible through the \b Watch window.
 
 In case of warnings or a test fail, the name of the test case source file is printed and the line of the failed test is
 reported between brackets (). The source files can be found under the <b>CMSIS RTOS2 Validation</b> group in the Project

--- a/Source/RV2_MessageQueue.c
+++ b/Source/RV2_MessageQueue.c
@@ -1104,6 +1104,7 @@ void TC_MsgQWait (void) {
 /*-----------------------------------------------------------------------------
  * TC_MsgQWait: Helper thread
  *----------------------------------------------------------------------------*/
+#if (TC_MSGQWAIT_EN)
 void Th_MsgQWait (void *arg) {
   uint32_t *p = (uint32_t *)arg;
   osStatus_t stat;
@@ -1128,6 +1129,7 @@ void Th_MsgQWait (void *arg) {
     }
   }
 }
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**
@@ -1203,6 +1205,7 @@ void TC_MsgQCheckTimeout (void) {
 /*-----------------------------------------------------------------------------
  * TC_MsgQCheckTimeout: Helper thread
  *----------------------------------------------------------------------------*/
+#if (TC_MSGQCHECKTIMEOUT_EN)
 void Th_MsgQWakeup (void *arg) {
   uint32_t msg;
 
@@ -1216,7 +1219,7 @@ void Th_MsgQWakeup (void *arg) {
   /* Explicitly terminate this thread */
   osThreadTerminate (osThreadGetId());
 }
-
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**

--- a/Source/RV2_Thread.c
+++ b/Source/RV2_Thread.c
@@ -625,6 +625,7 @@ void TC_osThreadGetState_2 (void) {
 /*-----------------------------------------------------------------------------
  * TC_osThreadGetState_2: Helper thread
  *----------------------------------------------------------------------------*/
+#if (TC_OSTHREADGGETSTATE_2_EN)
 void Th_osThreadGetState_2 (void *arg) {
   (void)arg;
 
@@ -632,6 +633,7 @@ void Th_osThreadGetState_2 (void *arg) {
 
 //  osThreadTerminate (osThreadGetId());
 }
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**
@@ -664,11 +666,13 @@ void TC_osThreadGetState_3 (void) {
 /*-----------------------------------------------------------------------------
  * TC_osThreadGetState_3: Helper thread
  *----------------------------------------------------------------------------*/
+#if (TC_OSTHREADGGETSTATE_3_EN)
 void Th_osThreadGetState_3 (void *arg) {
   (void)arg;
 
   osThreadTerminate (osThreadGetId());
 }
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**
@@ -1874,6 +1878,7 @@ void TC_ThreadMultiInstance (void) {
 /*-----------------------------------------------------------------------------
  * TC_ThreadMultiInstance: Helper thread
  *----------------------------------------------------------------------------*/
+#if (TC_THREADMULTIINSTANCE_EN)
 void Th_ThreadMultiInstance (void *arg) {
   uint8_t *var = (uint8_t *)arg;
   (*var)++;
@@ -1882,6 +1887,7 @@ void Th_ThreadMultiInstance (void *arg) {
   /* Explicitly terminate this thread */
   osThreadTerminate (osThreadGetId());
 }
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**
@@ -2040,6 +2046,7 @@ void TC_ThreadPriorityExec (void) {
 /*-----------------------------------------------------------------------------
  * TC_ThreadPriorityExec: Helper thread
  *----------------------------------------------------------------------------*/
+#if (TC_THREADPRIORITYEXEC_EN)
 void Th_ThreadPriorityExec (void *arg) {
   uint32_t i;
   for (i = 0; i < 7; i++) {
@@ -2052,6 +2059,7 @@ void Th_ThreadPriorityExec (void *arg) {
   /* Explicitly terminate this thread */
   osThreadTerminate (osThreadGetId());
 }
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**
@@ -2121,6 +2129,7 @@ void TC_ThreadYield (void) {
 /*-----------------------------------------------------------------------------
  * TC_ThreadYield: Helper thread
  *----------------------------------------------------------------------------*/
+#if (TC_THREADYIELD_EN)
 void Th_YieldTest (void *arg) {
   YIELD_TEST *cfg = (YIELD_TEST *)arg;
 
@@ -2137,6 +2146,7 @@ void Th_YieldTest (void *arg) {
   /* Explicitly terminate this thread */
   osThreadTerminate (osThreadGetId());
 }
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**
@@ -2170,6 +2180,7 @@ void TC_ThreadSuspendResume (void) {
 /*-----------------------------------------------------------------------------
  * TC_ThreadSuspendResume: Helper thread
  *----------------------------------------------------------------------------*/
+#if (TC_THREADSUSPENDRESUME_EN)
 void Th_SuspendResume (void *arg) {
   int32_t *cnt = (int32_t *)arg;
   osThreadId_t id = osThreadGetId();
@@ -2185,6 +2196,7 @@ void Th_SuspendResume (void *arg) {
   /* Explicitly terminate this thread */
   osThreadTerminate (osThreadGetId());
 }
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**
@@ -2213,11 +2225,13 @@ void TC_ThreadReturn (void) {
 /*-----------------------------------------------------------------------------
  * TC_ThreadReturn: Helper thread
  *----------------------------------------------------------------------------*/
+#if (TC_THREADRETURN_EN)
 void Th_ThreadReturn (void *arg) {
   (void)arg;
 
   return;
 }
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**

--- a/Source/RV2_Timer.c
+++ b/Source/RV2_Timer.c
@@ -357,7 +357,7 @@ void Irq_osTimerStart_1 (void) {
   - Call osTimerStart from one-shot timer callback to re-start the timer
 */
 void TC_osTimerStart_2 (void) {
-#if (TC_OSTIMERSTART_1_EN)
+#if (TC_OSTIMERSTART_2_EN)
   osTimerId_t id;
 
   Tim_Var_Os  = 0U;
@@ -394,6 +394,7 @@ void TC_osTimerStart_2 (void) {
 /*-----------------------------------------------------------------------------
  * TC_osTimerStart_2: Timer callback
  *----------------------------------------------------------------------------*/
+#if (TC_OSTIMERSTART_2_EN)
 void TimCb_osTimerStart_2  (void *arg) {
   osTimerId_t id = *(osTimerId_t *)arg;
 
@@ -401,6 +402,7 @@ void TimCb_osTimerStart_2  (void *arg) {
 
   Cb_osStatus = osTimerStart (id, 4U);
 }
+#endif
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 /**


### PR DESCRIPTION
- This also prevents DoxyGen to pull them into documentation