### PR TITLE
Remove tests that call RTOS2 API functions when interrupts are disabled (#35)

### DIFF
--- a/Source/RV2_EventFlags.c
+++ b/Source/RV2_EventFlags.c
@@ -160,7 +160,6 @@ The test cases check the Event Flags functions.
 \brief Test case: TC_osEventFlagsNew_1
 \details
   - Call osEventFlagsNew to create event flags object
-  - Call osEventFlagsNew with masked interrupts
   - Call osEventFlagsNew from ISR
 */
 void TC_osEventFlagsNew_1 (void) {
@@ -173,12 +172,6 @@ void TC_osEventFlagsNew_1 (void) {
 
   /* Delete created event flags */
   ASSERT_TRUE (osEventFlagsDelete(id) == osOK);
-
-  /* Call osEventFlagsNew with masked interrupts */
-  __disable_irq();
-  EventFlagsId = osEventFlagsNew (NULL);
-  __enable_irq();
-  ASSERT_TRUE (EventFlagsId == NULL);
 
   /* Call osEventFlags from ISR */
   TST_IRQHandler = Irq_osEventFlagsNew_1;
@@ -247,7 +240,6 @@ void TC_osEventFlagsNew_3 (void) {
 \brief Test case: TC_osEventFlagsSet_1
 \details
   - Call osEventFlagsSet to set all available flags in event flags object
-  - Call osEventFlagsSet with masked interrupts
   - Call osEventFlagsSet from ISR
 */
 void TC_osEventFlagsSet_1 (void) {
@@ -266,28 +258,6 @@ void TC_osEventFlagsSet_1 (void) {
     flags = (flags << 1U) | 1U;
     /* Call osEventFlagsSet to set all available flags in event flags object */
     rflags = osEventFlagsSet (id, set);
-    ASSERT_TRUE (rflags == flags);
-    set   = set << 1U;
-  }
-  while ((rflags == flags) && (set <= EVENT_FLAGS_MSK));
-
-  /* Delete event flags object */
-  ASSERT_TRUE (osEventFlagsDelete (id) == osOK);
-
-  /* Create event flags object */
-  id = osEventFlagsNew(NULL);
-  ASSERT_TRUE(id != NULL);
-
-  /* Call osEventFlagsSet with masked interrupts */
-  flags = 0U;
-  set   = 1U;
-  do {
-    flags = (flags << 1U) | 1U;
-    /* Call osEventFlagsSet to set all available flags in event flags object */
-      __disable_irq();
-    rflags = osEventFlagsSet (id, set);
-    __enable_irq();
-
     ASSERT_TRUE (rflags == flags);
     set   = set << 1U;
   }
@@ -339,7 +309,6 @@ void Irq_osEventFlagsSet_1 (void) {
 \brief Test case: TC_osEventFlagsClear_1
 \details
   - Call osEventFlagsClear to clear all available flags in event flags object
-  - Call osEventFlagsClear with masked interrupts
   - Call osEventFlagsClear from ISR
   - Call osEventFlagsClear with null object
 */
@@ -360,32 +329,6 @@ void TC_osEventFlagsClear_1 (void) {
   while ((clr & EVENT_FLAGS_MSK) != 0U) {
     /* Call osEventFlagsClear to clear all available flags in event flags object */
     rflags = osEventFlagsClear (id, clr);
-    if (ASSERT_TRUE (rflags == flags) == false) {
-      break;
-    }
-    clr   = (clr   << 1U);
-    flags = (flags << 1U) & EVENT_FLAGS_MSK;
-  }
-
-  /* Delete event flags object */
-  ASSERT_TRUE (osEventFlagsDelete (id) == osOK);
-
-  /* Create event flags object */
-  id = osEventFlagsNew(NULL);
-  ASSERT_TRUE(id != NULL);
-
-  /* Set all available flags */
-  osEventFlagsSet (id, EVENT_FLAGS_MSK);
-
-  /* Call osEventFlagsClear with masked interrupts */
-  flags = EVENT_FLAGS_MSK;
-  clr   = 1U;
-  while ((clr & EVENT_FLAGS_MSK) != 0U) {
-    /* Call osEventFlagsClear to clear all available flags in event flags object */
-    __disable_irq();
-    rflags = osEventFlagsClear (id, clr);
-    __enable_irq();
-
     if (ASSERT_TRUE (rflags == flags) == false) {
       break;
     }
@@ -443,7 +386,6 @@ void Irq_osEventFlagsClear_1 (void) {
 \details
   - Call osEventFlagsGet to retrieve the flags in event flags object when all flags are cleared
   - Call osEventFlagsGet to retrieve the flags in event flags object when all flags are set
-  - Call osEventFlagsGet with masked interrupts
   - Call osEventFlagsGet from ISR
   - Call osEventFlagsGet with null object
 */
@@ -474,12 +416,6 @@ void TC_osEventFlagsGet_1 (void) {
   /* Set flags of random pattern */
   osEventFlagsSet (id, 0x55AA55AA & EVENT_FLAGS_MSK);
 
-  /* Call osEventFlagsGet with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osEventFlagsGet(id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == (0x55AA55AA & EVENT_FLAGS_MSK));
-
   /* Call osEventFlagsGet from ISR */
   TST_IRQHandler = Irq_osEventFlagsGet_1;
   EventFlagsId = id;
@@ -508,7 +444,6 @@ void Irq_osEventFlagsGet_1 (void) {
 \details
   - Call osEventFlagsWait without timeout to retrieve the event flags
   - Call osEventFlagsWait with timeout to retrieve the event flags
-  - Call osEventFlagsWait with masked interrupts
   - Call osEventFlagsWait from ISR with timeout
   - Call osEventFlagsWait from ISR without timeout
   - Call osEventFlagsWait with null object
@@ -553,17 +488,6 @@ void TC_osEventFlagsWait_1 (void) {
 
   /* Set flags of random pattern */
   osEventFlagsSet (id, 0x55AA55AA & EVENT_FLAGS_MSK);
-
-  /* Call osEventFlagsWait with masked interrupts (with and without timeout) */
-  __disable_irq();
-  Isr_u32 = osEventFlagsWait (id, 0x55AA55AA & EVENT_FLAGS_MSK, osFlagsWaitAll, osWaitForever);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == osFlagsErrorParameter);
-
-  __disable_irq();
-  Isr_u32 = osEventFlagsWait (id, 0x55AA55AA & EVENT_FLAGS_MSK, osFlagsWaitAny, 0U);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == (0x55AA55AA & EVENT_FLAGS_MSK));
 
   /* Set flags of random pattern */
   osEventFlagsSet (id, 0x55AA55AA & EVENT_FLAGS_MSK);
@@ -629,7 +553,6 @@ void Irq_osEventFlagsWait_1 (void) {
 \brief Test case: TC_osEventFlagsDelete_1
 \details
   - Call osEventFlagsDelete to delete a event flags object
-  - Call osEventFlagsDelete with masked interrupts
   - Call osEventFlagsDelete from ISR
   - Call osEventFlagsDelete with null object
 */
@@ -647,12 +570,6 @@ void TC_osEventFlagsDelete_1 (void) {
   /* Create event flags object */
   id = osEventFlagsNew (NULL);
   ASSERT_TRUE (id != NULL);
-
-  /* Call osEventFlagsDelete with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osEventFlagsDelete (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osEventFlagsDelete from ISR */
   TST_IRQHandler = Irq_osEventFlagsDelete_1;
@@ -685,7 +602,6 @@ void Irq_osEventFlagsDelete_1 (void) {
   - Call osEventFlagsGetName to retrieve a name of an unnamed event flags
   - Call osEventFlagsGetName to retrieve a name of a event flags with assigned name
   - Call osEventFlagsGetName with valid object
-  - Call osEventFlagsGetName with masked interrupts
   - Call osEventFlagsGetName from ISR
   - Call osEventFlagsGetName with null object
 */
@@ -714,12 +630,6 @@ void TC_osEventFlagsGetName_1 (void) {
 
   /* Call osEventFlagsGetName to retrieve a name of a event flags with assigned name */
   ASSERT_TRUE (strcmp(osEventFlagsGetName(id), name) == 0U);
-
-  /* Call osEventFlagsGetName with masked interrupts */
-  __disable_irq();
-  EventFlagsName = osEventFlagsGetName(id);
-  __enable_irq();
-  ASSERT_TRUE (strcmp(EventFlagsName, name) != 0U);
 
   /* Call osEventFlagsGetName from ISR */
   TST_IRQHandler = Irq_osEventFlagsGetName_1;

--- a/Source/RV2_Kernel.c
+++ b/Source/RV2_Kernel.c
@@ -57,19 +57,13 @@ underlying kernel and the CMSIS-RTOS API. The test cases check the functions ret
 /**
 \brief Test case: TC_osKernelInitialize_1
 \details
-  -  Call osKernelInitialize when the kernel is already initialized
-  -  Call osKernelInitialize with masked interrupts
+  - Call osKernelInitialize when the kernel is already initialized
+  - Call osKernelInitialize from ISR
 */
 void TC_osKernelInitialize_1 (void) {
 #if (TC_OSKERNELINITIALIZE_1_EN)
   /* Call osKernelInitialize when the kernel is already initialized */
   ASSERT_TRUE (osKernelInitialize() == osError);
-
-  /* Call osKernelInitialize with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osKernelInitialize();
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osKernelInitialize from ISR */
   TST_IRQHandler = Irq_osKernelInitialize;
@@ -93,7 +87,6 @@ void Irq_osKernelInitialize (void) {
 \brief Test case: TC_osKernelGetInfo_1
 \details
   - Call osKernelGetInfo and check that returned structures are populated
-  - Call osKernelGetInfo with masked interrupts
   - Call osKernelGetInfo with argument version equal to NULL
   - Call osKernelGetInfo with argument id_buf equal to NULL
   - Call osKernelGetInfo with argument id_size equal to 0
@@ -113,12 +106,6 @@ void TC_osKernelGetInfo_1 (void) {
   ASSERT_TRUE (os_version.api    != 0U);
   ASSERT_TRUE (os_version.kernel != 0U);
   ASSERT_TRUE (id[0] != '\0');
-
-  /* Call osKernelGetInfo with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osKernelGetInfo(&os_version, id, sizeof(id));
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osOK);
 
   /* Call osKernelGetInfo with argument version equal to NULL */
   id[0] = '\0';
@@ -172,7 +159,6 @@ void Irq_osKernelGetInfo (void) {
   - Call osKernelGetState when the kernel is running
   - Call osKernelGetState when the kernel is locked
   - Call osKernelGetState after the kernel is unlocked
-  - Call osKernelGetState with masked interrupts
   - Call osKernelGetState from ISR
 */
 void TC_osKernelGetState_1 (void) {
@@ -187,12 +173,6 @@ void TC_osKernelGetState_1 (void) {
   /* Call osKernelGetState after the kernel is unlocked */
   osKernelUnlock();
   ASSERT_TRUE (osKernelGetState() == osKernelRunning);
-
-  /* Call osKernelGetState with masked interrupts */
-  __disable_irq();
-  Isr_osKernelState = osKernelGetState();
-  __enable_irq();
-  ASSERT_TRUE (Isr_osKernelState == osKernelRunning);
 
   /* Call osKernelGetState from ISR */
   TST_IRQHandler = Irq_osKernelGetState;
@@ -235,7 +215,6 @@ void TC_osKernelGetState_2 (void) {
 \brief Test case: TC_osKernelStart_1
 \details
   - Call osKernelStart when the kernel is already running
-  - Call osKernelStart with masked interrupts
   - Call osKernelStart from ISR
 */
 void TC_osKernelStart_1 (void) {
@@ -245,12 +224,6 @@ void TC_osKernelStart_1 (void) {
 
   /* Call osKernelStart when the kernel is already running */
   ASSERT_TRUE (osKernelStart() == osError);
-
-  /* Call osKernelStart with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osKernelStart();
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osKernelStart from ISR */
   TST_IRQHandler = Irq_osKernelStart;
@@ -274,7 +247,6 @@ void Irq_osKernelStart (void) {
 \brief Test case: TC_osKernelLock_1
 \details
   - Call osKernelLock to try lock already locked kernel
-  - Call osKernelLock with masked interrupts
   - Call osKernelLock from ISR
 */
 void TC_osKernelLock_1 (void) {
@@ -291,12 +263,6 @@ void TC_osKernelLock_1 (void) {
 
   /* Unlock kernel */
   osKernelUnlock();
-
-  /* Call osKernelLock with masked interrupts */
-  __disable_irq();
-  Isr_s32 = osKernelLock();
-  __enable_irq();
-  ASSERT_TRUE (Isr_s32 == osErrorISR);
 
   /* Call osKernelLock from ISR */
   TST_IRQHandler = Irq_osKernelLock;
@@ -337,7 +303,6 @@ void TC_osKernelLock_2 (void) {
 \brief Test case: TC_osKernelUnlock_1
 \details
   - Call osKernelUnlock to try unlock running kernel
-  - Call osKernelUnlock with masked interrupts
   - Call osKernelUnlock from ISR
 */
 void TC_osKernelUnlock_1 (void) {
@@ -353,12 +318,6 @@ void TC_osKernelUnlock_1 (void) {
   /* Call osKernelUnlock to try unlock running kernel */
   ASSERT_TRUE (osKernelUnlock() == 0U);
   ASSERT_TRUE (osKernelGetState() == osKernelRunning);
-
-  /* Call osKernelUnlock with masked interrupts */
-  __disable_irq();
-  Isr_s32 = osKernelUnlock();
-  __enable_irq();
-  ASSERT_TRUE (Isr_s32 == osErrorISR);
 
   /* Call osKernelUnlock from ISR */
   TST_IRQHandler = Irq_osKernelUnlock;
@@ -438,7 +397,6 @@ void Irq_osKernelRestoreLock (void) {
   - Call osKernelSuspend to suspend the kernel when no other RTOS objects are active
   - Call osKernelSuspend when the kernel is already suspended
   - Call osKernelSuspend to suspend the kernel with other RTOS objects active
-  - Call osKernelSuspend with masked interrupts
   - Call osKernelSuspend from ISR
 */
 void TC_osKernelSuspend_1 (void) {
@@ -477,12 +435,6 @@ void TC_osKernelSuspend_1 (void) {
 
   /* Terminate the thread */
   ASSERT_TRUE (osThreadTerminate (id) == osOK);
-
-  /* Call osKernelSuspend with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osKernelSuspend();
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == 0U);
 
   /* Call osKernelSuspend from ISR */
   TST_IRQHandler = Irq_osKernelSuspend;
@@ -523,7 +475,6 @@ void Irq_osKernelSuspend (void) {
 \brief Test case: TC_osKernelResume_1
 \details
   - Call osKernelResume to resume suspended kernel
-  - Call osKernelResume with masked interrupts
   - Call osKernelResume from ISR
 */
 void TC_osKernelResume_1 (void) {
@@ -565,12 +516,6 @@ void TC_osKernelResume_1 (void) {
 
   /* Suspend the kernel */
   ASSERT_TRUE (osKernelSuspend () > 0U);
-  ASSERT_TRUE (osKernelGetState() == osKernelSuspended);
-
-  /* Call osKernelResume with masked interrupts */
-  __disable_irq();
-  osKernelResume(0U);
-  __enable_irq();
   ASSERT_TRUE (osKernelGetState() == osKernelSuspended);
 
   /* Call osKernelResume from ISR */
@@ -615,7 +560,6 @@ void Irq_osKernelResume (void) {
 \details
   - Call osKernelGetTickCount and check that returned value is non-zero
   - Call osKernelGetTickCount twice with an osDelay of 100 ticks in between
-  - Call osKernelGetTickCount with masked interrupts
   - Call osKernelGetTickCount from ISR
 */
 void TC_osKernelGetTickCount_1 (void) {
@@ -636,12 +580,6 @@ void TC_osKernelGetTickCount_1 (void) {
   osDelay(100U);
   cnt = osKernelGetTickCount() - cnt;
   ASSERT_TRUE (cnt == 100U);
-
-  /* Call osKernelGetTickCount with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osKernelGetTickCount();
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 > 0U);
 
   /* Call osKernelGetTickCount from ISR */
   TST_IRQHandler = Irq_osKernelGetTickCount;
@@ -666,7 +604,6 @@ void Irq_osKernelGetTickCount (void) {
 \details
   - Call osKernelGetTickFreq and check that returned value is non-zero
   - Call osKernelGetTickFreq and check that returned value equals to predefine tick frequency
-  - Call osKernelGetTickFreq with masked interrupts
   - Call osKernelGetTickFreq from ISR
 */
 void TC_osKernelGetTickFreq_1 (void) {
@@ -676,12 +613,6 @@ void TC_osKernelGetTickFreq_1 (void) {
 
   /* Call osKernelGetTickFreq and check that returned value equals to predefine tick frequency */
   ASSERT_TRUE (osKernelGetTickFreq() == RTOS2_TICK_FREQ);
-
-  /* Call osKernelGetTickFreq with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osKernelGetTickFreq();
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == RTOS2_TICK_FREQ);
 
   /* Call osKernelGetTickFreq from ISR */
   TST_IRQHandler = Irq_osKernelGetTickFreq;
@@ -706,7 +637,6 @@ void Irq_osKernelGetTickFreq (void) {
 \details
   - Call osKernelGetSysTimerCount and check that returned value is non-zero
   - Call osKernelGetSysTimerCount twice with an osDelay of 100 ticks in between
-  - Call osKernelGetSysTimerCount with masked interrupts
   - Call osKernelGetSysTimerCount from ISR
 */
 void TC_osKernelGetSysTimerCount_1 (void) {
@@ -726,12 +656,6 @@ void TC_osKernelGetSysTimerCount_1 (void) {
   cnt /= (osKernelGetSysTimerFreq()/RTOS2_TICK_FREQ);
   ASSERT_TRUE (cnt >=  99U);
   ASSERT_TRUE (cnt <= 101U);
-
-  /* Call osKernelGetSysTimerCount with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osKernelGetSysTimerCount();
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 > 0U);
 
   /* Call osKernelGetSysTimerCount from ISR */
   TST_IRQHandler = Irq_osKernelGetSysTimerCount;
@@ -755,19 +679,12 @@ void Irq_osKernelGetSysTimerCount (void) {
 \brief Test case: TC_osKernelGetSysTimerFreq_1
 \details
   - Call osKernelGetSysTimerFreq and check that returned value is non-zero
-  - Call osKernelGetSysTimerFreq with masked interrupts
   - Call osKernelGetSysTimerFreq from ISR
 */
 void TC_osKernelGetSysTimerFreq_1 (void) {
 #if (TC_OSKERNELGETSYSTIMERFREQ_EN)
   /* Call osKernelGetSysTimerFreq and check that returned value is non-zero */
   ASSERT_TRUE (osKernelGetSysTimerFreq() > 0U);
-
-  /* Call osKernelGetSysTimerFreq with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osKernelGetSysTimerFreq();
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 > 0U);
 
   /* Call osKernelGetSysTimerFreq from ISR */
   TST_IRQHandler = Irq_osKernelGetSysTimerFreq;

--- a/Source/RV2_MemoryPool.c
+++ b/Source/RV2_MemoryPool.c
@@ -68,7 +68,6 @@ The test cases check the osPool* functions.
 \brief Test case: TC_osMemoryPoolNew_1
 \details
   - Call osMemoryPoolNew to create a memory pool object
-  - Call osMemoryPoolNew with masked interrupts
   - Call osMemoryPoolNew from ISR
 */
 void TC_osMemoryPoolNew_1 (void) {
@@ -81,12 +80,6 @@ void TC_osMemoryPoolNew_1 (void) {
 
   /* Delete created memory pool */
   ASSERT_TRUE (osMemoryPoolDelete(id) == osOK);
-
-  /* Call osMemoryPoolNew with masked interrupts */
-  __disable_irq();
-  MemoryPoolId = osMemoryPoolNew (1U, 4U, NULL);
-  __enable_irq();
-  ASSERT_TRUE (MemoryPoolId == NULL);
 
   /* Call osMemoryPoolNew from ISR */
   TST_IRQHandler = Irq_osMemoryPoolNew_1;
@@ -159,7 +152,6 @@ void TC_osMemoryPoolNew_3 (void) {
   - Call osMemoryPoolGetName to retrieve a name of an unnamed memory pool
   - Call osMemoryPoolGetName to retrieve a name of a memory pool with assigned name
   - Call osMemoryPoolGetName with valid object
-  - Call osMemoryPoolGetName with masked interrupts
   - Call osMemoryPoolGetName from ISR
   - Call osMemoryPoolGetName with null object
 */
@@ -188,12 +180,6 @@ void TC_osMemoryPoolGetName_1 (void) {
 
   /* Call osMemoryPoolGetName to retrieve a name of a memory pool with assigned name */
   ASSERT_TRUE (strcmp(osMemoryPoolGetName(id), name) == 0U);
-
-  /* Call osMemoryPoolGetName with masked interrupts */
-  __disable_irq();
-  MemoryPoolName = osMemoryPoolGetName(id);
-  __enable_irq();
-  ASSERT_TRUE (strcmp(MemoryPoolName, name) != 0U);
 
   /* Call osMemoryPoolGetName from ISR */
   TST_IRQHandler = Irq_osMemoryPoolGetName_1;
@@ -224,8 +210,6 @@ void Irq_osMemoryPoolGetName_1 (void) {
 \brief Test case: TC_osMemoryPoolAlloc_1
 \details
   - Call osMemoryPoolAlloc to allocate a memory block from the memory pool
-  - Call osMemoryPoolAlloc with masked interrupts and timeout == 0
-  - Call osMemoryPoolAlloc with masked interrupts and timeout != 0
   - Call osMemoryPoolAlloc from ISR with timeout == 0
   - Call osMemoryPoolAlloc from ISR with timeout != 0
   - Call osMemoryPoolAlloc with null object
@@ -242,26 +226,6 @@ void TC_osMemoryPoolAlloc_1 (void) {
   /* Call osMemoryPoolAlloc to allocate a memory block from the memory pool */
   p = osMemoryPoolAlloc (id, 10U);
   ASSERT_TRUE (p != NULL);
-
-  /* Delete memory pool */
-  osMemoryPoolDelete (id);
-
-
-  /* Create a memory pool */
-  id = osMemoryPoolNew (MEMBL_CNT, MEMBL_SZ, NULL);
-  ASSERT_TRUE(id != NULL);
-
-  /* Call osMemoryPoolAlloc with masked interrupts and timeout == 0 */
-  __disable_irq();
-  Isr_pv = osMemoryPoolAlloc (id, 0U);
-  __enable_irq();
-  ASSERT_TRUE (Isr_pv != NULL);
-
-  /* Call osMemoryPoolAlloc with masked interrupts and timeout != 0*/
-  __disable_irq();
-  Isr_pv = osMemoryPoolAlloc (id, osWaitForever);
-  __enable_irq();
-  ASSERT_TRUE (Isr_pv == NULL);
 
   /* Delete memory pool */
   osMemoryPoolDelete (id);
@@ -332,7 +296,6 @@ void Irq_osMemoryPoolAlloc_1 (void) {
 \brief Test case: TC_osMemoryPoolFree_1
 \details
   - Call osMemoryPoolFree to free a memory block from the memory pool
-  - Call osMemoryPoolFree with masked interrupts
   - Call osMemoryPoolFree from ISR
   - Call osMemoryPoolFree with null object
   - Call osMemoryPoolFree from ISR with null object
@@ -353,16 +316,6 @@ void TC_osMemoryPoolFree_1 (void) {
 
   /* Call osMemoryPoolFree to free a memory block from the memory pool */
   ASSERT_TRUE (osMemoryPoolFree (id, p) == osOK);
-
-  /* Allocate one block */
-  p = osMemoryPoolAlloc (id, 10U);
-  ASSERT_TRUE (p != NULL);
-
-  /* Call osMemoryPoolFree with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osMemoryPoolFree (id, p);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osOK);
 
   /* Allocate one block */
   p = osMemoryPoolAlloc (id, 10U);
@@ -435,7 +388,6 @@ void Irq_osMemoryPoolFree_1 (void) {
 \brief Test case: TC_osMemoryPoolGetCapacity_1
 \details
   - Call osMemoryPoolGetCapacity to retrieve the maximum number of available memory blocks
-  - Call osMemoryPoolGetCapacity with masked interrupts
   - Call osMemoryPoolGetCapacity from ISR
   - Call osMemoryPoolGetCapacity from ISR with null object
   - Call osMemoryPoolGetCapacity with null object
@@ -450,12 +402,6 @@ void TC_osMemoryPoolGetCapacity_1 (void) {
 
   /* Call osMemoryPoolGetCapacity to retrieve the maximum number of available memory blocks */
   ASSERT_TRUE (osMemoryPoolGetCapacity (id) == MEMBL_CNT);
-
-  /* Call osMemoryPoolGetCapacity with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osMemoryPoolGetCapacity (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == MEMBL_CNT);
 
   /* Call osMemoryPoolGetCapacity from ISR */
   TST_IRQHandler = Irq_osMemoryPoolGetCapacity_1;
@@ -503,7 +449,6 @@ void Irq_osMemoryPoolGetCapacity_1 (void) {
 \brief Test case: TC_osMemoryPoolGetBlockSize_1
 \details
   - Call osMemoryPoolGetBlockSize to retrieve the memory block size
-  - Call osMemoryPoolGetBlockSize with masked interrupts
   - Call osMemoryPoolGetBlockSize from ISR
   - Call osMemoryPoolGetBlockSize from ISR with null object
   - Call osMemoryPoolGetBlockSize with null object
@@ -518,12 +463,6 @@ void TC_osMemoryPoolGetBlockSize_1 (void) {
 
   /* Call osMemoryPoolGetBlockSize to retrieve the memory block size */
   ASSERT_TRUE (osMemoryPoolGetBlockSize (id) == MEMBL_SZ);
-
-  /* Call osMemoryPoolGetBlockSize with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osMemoryPoolGetBlockSize (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == MEMBL_SZ);
 
   /* Call osMemoryPoolGetBlockSize from ISR */
   TST_IRQHandler = Irq_osMemoryPoolGetBlockSize_1;
@@ -571,7 +510,6 @@ void Irq_osMemoryPoolGetBlockSize_1 (void) {
 \brief Test case: TC_osMemoryPoolGetCount_1
 \details
   - Call osMemoryPoolGetCount to retrieve the number of memory blocks used
-  - Call osMemoryPoolGetCount with masked interrupts
   - Call osMemoryPoolGetCount from ISR
   - Call osMemoryPoolGetCount from ISR with null object
   - Call osMemoryPoolGetCount with null object
@@ -591,12 +529,6 @@ void TC_osMemoryPoolGetCount_1 (void) {
 
   /* Call osMemoryPoolGetCount to retrieve the number of memory blocks used */
   ASSERT_TRUE (osMemoryPoolGetCount (id) == 1U);
-
-  /* Call osMemoryPoolGetCount with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osMemoryPoolGetCount (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == 1U);
 
   /* Call osMemoryPoolGetCount from ISR */
   TST_IRQHandler = Irq_osMemoryPoolGetCount_1;
@@ -644,7 +576,6 @@ void Irq_osMemoryPoolGetCount_1 (void) {
 \brief Test case: TC_osMemoryPoolGetSpace_1
 \details
   - Call osMemoryPoolGetSpace to retrieve the number of available memory blocks
-  - Call osMemoryPoolGetSpace with masked interrupts
   - Call osMemoryPoolGetSpace from ISR
   - Call osMemoryPoolGetSpace from ISR with null object
   - Call osMemoryPoolGetSpace with null object
@@ -664,12 +595,6 @@ void TC_osMemoryPoolGetSpace_1 (void) {
 
   /* Call osMemoryPoolGetSpace to retrieve the number of available memory blocks */
   ASSERT_TRUE (osMemoryPoolGetSpace (id) == (MEMBL_CNT-1U));
-
-  /* Call osMemoryPoolGetSpace with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osMemoryPoolGetSpace (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == (MEMBL_CNT-1U));
 
   /* Call osMemoryPoolGetSpace from ISR */
   TST_IRQHandler = Irq_osMemoryPoolGetSpace_1;
@@ -717,7 +642,6 @@ void Irq_osMemoryPoolGetSpace_1 (void) {
 \brief Test case: TC_osMemoryPoolDelete_1
 \details
   - Call osMemoryPoolDelete to delete a memory pool
-  - Call osMemoryPoolDelete with masked interrupts
   - Call osMemoryPoolDelete from ISR
   - Call osMemoryPoolDelete with null object
 */
@@ -735,12 +659,6 @@ void TC_osMemoryPoolDelete_1 (void) {
   /* Create a memory pool object */
   id = osMemoryPoolNew (MEMBL_CNT, MEMBL_SZ, NULL);
   ASSERT_TRUE (id != NULL);
-
-  /* Call osMemoryPoolDelete with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osMemoryPoolDelete (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osMemoryPoolDelete from ISR */
   TST_IRQHandler = Irq_osMemoryPoolDelete_1;

--- a/Source/RV2_MessageQueue.c
+++ b/Source/RV2_MessageQueue.c
@@ -66,7 +66,6 @@ The test cases check the osMessage* functions.
 \brief Test case: TC_osMessageQueueNew_1
 \details
   - Call osMessageQueueNew to create a message queue object
-  - Call osMessageQueueNew with masked interrupts
   - Call osMessageQueueNew from ISR
 */
 void TC_osMessageQueueNew_1 (void) {
@@ -79,12 +78,6 @@ void TC_osMessageQueueNew_1 (void) {
 
   /* Delete created message queue */
   ASSERT_TRUE (osMessageQueueDelete(id) == osOK);
-
-  /* Call osMessageQueueNew with masked interrupts */
-  __disable_irq();
-  MessageQueueId = osMessageQueueNew (1U, 4U, NULL);
-  __enable_irq();
-  ASSERT_TRUE (MessageQueueId == NULL);
 
   /* Call osMessageQueueNew from ISR */
   TST_IRQHandler = Irq_osMessageQueueNew_1;
@@ -157,7 +150,6 @@ void TC_osMessageQueueNew_3 (void) {
   - Call osMessageQueueGetName to retrieve a name of an unnamed message queue
   - Call osMessageQueueGetName to retrieve a name of a message queue with assigned name
   - Call osMessageQueueGetName with valid object
-  - Call osMessageQueueGetName with masked interrupts
   - Call osMessageQueueGetName from ISR
   - Call osMessageQueueGetName with null object
 */
@@ -186,12 +178,6 @@ void TC_osMessageQueueGetName_1 (void) {
 
   /* Call osMessageQueueGetName to retrieve a name of a message queue with assigned name */
   ASSERT_TRUE (strcmp(osMessageQueueGetName(id), name) == 0U);
-
-  /* Call osMessageQueueGetName with masked interrupts */
-  __disable_irq();
-  MessageQueueName = osMessageQueueGetName(id);
-  __enable_irq();
-  ASSERT_TRUE (strcmp(MessageQueueName, name) != 0U);
 
   /* Call osMessageQueueGetName from ISR */
   TST_IRQHandler = Irq_osMessageQueueGetName_1;
@@ -222,8 +208,6 @@ void Irq_osMessageQueueGetName_1 (void) {
 \brief Test case: TC_osMessageQueuePut_1
 \details
   - Call osMessageQueuePut to put message into the queue
-  - Call osMessageQueuePut with masked interrupts and timeout == 0
-  - Call osMessageQueuePut with masked interrupts and timeout != 0
   - Call osMessageQueuePut from ISR with timeout == 0
   - Call osMessageQueuePut from ISR with timeout != 0
   - Call osMessageQueuePut with null object
@@ -240,26 +224,6 @@ void TC_osMessageQueuePut_1 (void) {
 
   /* Call osMessageQueuePut to put message into the queue */
   ASSERT_TRUE (osMessageQueuePut (id, &msg, 0U, 0U) == osOK);
-
-  /* Delete Message Queue */
-  ASSERT_TRUE (osMessageQueueDelete (id) == osOK);
-
-
-  /* Create a message queue */
-  id = osMessageQueueNew (MSGQ_CNT, MSGQ_SZ, NULL);
-  ASSERT_TRUE (id != NULL);
-
-  /* Call osMessageQueuePut with masked interrupts and timeout == 0 */
-  __disable_irq();
-  Isr_osStatus = osMessageQueuePut (id, &msg, 0U, 0U);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osOK);
-
-  /* Call osMessageQueuePut with masked interrupts and timeout != 0 */
-  __disable_irq();
-  Isr_osStatus = osMessageQueuePut (id, &msg, 0U, osWaitForever);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorParameter);
 
   /* Delete Message Queue */
   ASSERT_TRUE (osMessageQueueDelete (id) == osOK);
@@ -397,8 +361,6 @@ void Irq_osMessageQueuePut_2 (void) {
 \brief Test case: TC_osMessageQueueGet_1
 \details
   - Call osMessageQueueGet to get message from the queue
-  - Call osMessageQueueGet with masked interrupts and timeout == 0
-  - Call osMessageQueueGet with masked interrupts and timeout != 0
   - Call osMessageQueueGet from ISR with timeout == 0
   - Call osMessageQueueGet from ISR with timeout != 0
   - Call osMessageQueueGet with null object
@@ -423,33 +385,6 @@ void TC_osMessageQueueGet_1 (void) {
 
   /* Check that correct message was retrieved */
   ASSERT_TRUE (msg == msg_in);
-
-  /* Delete Message Queue */
-  ASSERT_TRUE (osMessageQueueDelete (id) == osOK);
-
-
-  /* Create a message queue */
-  id = osMessageQueueNew (MSGQ_CNT, MSGQ_SZ, NULL);
-  ASSERT_TRUE (id != NULL);
-
-  /* Put message into the queue */
-  msg_in = 2U;
-  ASSERT_TRUE (osMessageQueuePut (id, &msg_in, 0U, 0U) == osOK);
-
-  /* Call osMessageQueueGet with masked interrupts and timeout == 0 */
-  __disable_irq();
-  Isr_osStatus = osMessageQueueGet (id, &msg, 0U, 0U);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osOK);
-
-  /* Check that correct message was retrieved */
-  ASSERT_TRUE (msg == msg_in);
-
-  /* Call osMessageQueueGet with masked interrupts and timeout != 0 */
-  __disable_irq();
-  Isr_osStatus = osMessageQueueGet (id, &msg, 0U, osWaitForever);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorParameter);
 
   /* Delete Message Queue */
   ASSERT_TRUE (osMessageQueueDelete (id) == osOK);
@@ -592,7 +527,6 @@ void Irq_osMessageQueueGet_2 (void) {
 \brief Test case: TC_osMessageQueueGetCapacity_1
 \details
   - Call osMessageQueueGetCapacity to retrieve the maximum number of messages in the message queue
-  - Call osMessageQueueGetCapacity with masked interrupts
   - Call osMessageQueueGetCapacity from ISR
   - Call osMessageQueueGetCapacity from ISR with null object
   - Call osMessageQueueGetCapacity with null object
@@ -607,12 +541,6 @@ void TC_osMessageQueueGetCapacity_1 (void) {
 
   /* Call osMessageQueueGetCapacity to retrieve the maximum number of messages in the message queue */
   ASSERT_TRUE (osMessageQueueGetCapacity (id) == MSGQ_CNT);
-
-  /* Call osMessageQueueGetCapacity with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osMessageQueueGetCapacity (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == MSGQ_CNT);
 
   /* Call osMessageQueueGetCapacity from ISR */
   TST_IRQHandler = Irq_osMessageQueueGetCapacity_1;
@@ -660,7 +588,6 @@ void Irq_osMessageQueueGetCapacity_1 (void) {
 \brief Test case: TC_osMessageQueueGetMsgSize_1
 \details
   - Call osMessageQueueGetMsgSize to retrieve the maximum message size
-  - Call osMessageQueueGetMsgSize with masked interrupts
   - Call osMessageQueueGetMsgSize from ISR
   - Call osMessageQueueGetMsgSize from ISR with null object
   - Call osMessageQueueGetMsgSize with null object
@@ -675,12 +602,6 @@ void TC_osMessageQueueGetMsgSize_1 (void) {
 
   /* Call osMessageQueueGetMsgSize to retrieve the maximum message size */
   ASSERT_TRUE (osMessageQueueGetMsgSize (id) == MSGQ_SZ);
-
-  /* Call osMessageQueueGetMsgSize with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osMessageQueueGetMsgSize (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == MSGQ_SZ);
 
   /* Call osMessageQueueGetMsgSize from ISR */
   TST_IRQHandler = Irq_osMessageQueueGetMsgSize_1;
@@ -728,7 +649,6 @@ void Irq_osMessageQueueGetMsgSize_1 (void) {
 \brief Test case: TC_osMessageQueueGetCount_1
 \details
   - Call osMessageQueueGetCount to retrieve the number of queued messages
-  - Call osMessageQueueGetCount with masked interrupts
   - Call osMessageQueueGetCount from ISR
   - Call osMessageQueueGetCount from ISR with null object
   - Call osMessageQueueGetCount with null object
@@ -748,12 +668,6 @@ void TC_osMessageQueueGetCount_1 (void) {
 
   /* Call osMessageQueueGetCount to retrieve the number of queued messages */
   ASSERT_TRUE (osMessageQueueGetCount (id) == 1U);
-
-  /* Call osMessageQueueGetCount with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osMessageQueueGetCount (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == 1U);
 
   /* Call osMessageQueueGetCount from ISR */
   TST_IRQHandler = Irq_osMessageQueueGetCount_1;
@@ -801,7 +715,6 @@ void Irq_osMessageQueueGetCount_1 (void) {
 \brief Test case: TC_osMessageQueueGetSpace_1
 \details
   - Call osMessageQueueGetSpace to retrieve the number of available message slots
-  - Call osMessageQueueGetSpace with masked interrupts
   - Call osMessageQueueGetSpace from ISR
   - Call osMessageQueueGetSpace from ISR with null object
   - Call osMessageQueueGetSpace with null object
@@ -821,12 +734,6 @@ void TC_osMessageQueueGetSpace_1 (void) {
 
   /* Call osMessageQueueGetSpace to retrieve the number of available message slots */
   ASSERT_TRUE (osMessageQueueGetSpace (id) == (MSGQ_CNT-1U));
-
-  /* Call osMessageQueueGetSpace with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osMessageQueueGetSpace (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == (MSGQ_CNT-1U));
 
   /* Call osMessageQueueGetSpace from ISR */
   TST_IRQHandler = Irq_osMessageQueueGetSpace_1;
@@ -874,7 +781,6 @@ void Irq_osMessageQueueGetSpace_1 (void) {
 /**
 \brief Test case: TC_osMessageQueueReset_1
 \details
-  - Call osMessageQueueReset with masked interrupts
   - Call osMessageQueueReset from ISR
   - Call osMessageQueueReset with null object id
 */
@@ -896,12 +802,6 @@ void TC_osMessageQueueReset_1 (void) {
 
   /* Check that the message queue was reset */
   ASSERT_TRUE (osMessageQueueGetSpace (id) == MSGQ_CNT);
-
-  /* Call osMessageQueueReset with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osMessageQueueReset (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osMessageQueueReset from ISR */
   TST_IRQHandler = Irq_osMessageQueueReset_1;
@@ -933,7 +833,6 @@ void Irq_osMessageQueueReset_1 (void) {
 \details
   - Call osMessageQueueDelete to delete empty message queue
   - Call osMessageQueueDelete to delete non-empty message queue
-  - Call osMessageQueueDelete with masked interrupts
   - Call osMessageQueueDelete from ISR
   - Call osMessageQueueDelete with null object
 */
@@ -963,12 +862,6 @@ void TC_osMessageQueueDelete_1 (void) {
   /* Create a message queue */
   id = osMessageQueueNew (MSGQ_CNT, MSGQ_SZ, NULL);
   ASSERT_TRUE (id != NULL);
-
-  /* Call osMessageQueueDelete with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osMessageQueueDelete (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osMessageQueueDelete from ISR */
   TST_IRQHandler = Irq_osMessageQueueDelete_1;

--- a/Source/RV2_Mutex.c
+++ b/Source/RV2_Mutex.c
@@ -251,7 +251,6 @@ The test cases check the osMutex* functions.
 \brief Test case: TC_osMutexNew_1
 \details
   - Call osMutexNew to create a mutex object
-  - Call osMutexNew with masked interrupts
   - Call osMutexNew from ISR
 */
 void TC_osMutexNew_1 (void) {
@@ -264,12 +263,6 @@ void TC_osMutexNew_1 (void) {
 
   /* Delete created mutex */
   ASSERT_TRUE (osMutexDelete(id) == osOK);
-
-  /* Call osMutexNew with masked interrupts */
-  __disable_irq();
-  MutexId = osMutexNew (NULL);
-  __enable_irq();
-  ASSERT_TRUE (MutexId == NULL);
 
   /* Call osMutexNew from ISR */
   TST_IRQHandler = Irq_osMutexNew_1;
@@ -400,7 +393,6 @@ void TC_osMutexNew_6 (void) {
   - Call osMutexGetName to retrieve a name of an unnamed mutex
   - Call osMutexGetName to retrieve a name of a mutex with assigned name
   - Call osMutexGetName with valid object
-  - Call osMutexGetName with masked interrupts
   - Call osMutexGetName from ISR
   - Call osMutexGetName with null object
 */
@@ -429,12 +421,6 @@ void TC_osMutexGetName_1 (void) {
 
   /* Call osMutexGetName to retrieve a name of a mutex with assigned name */
   ASSERT_TRUE (strcmp(osMutexGetName(id), name) == 0U);
-
-  /* Call osMutexGetName with masked interrupts */
-  __disable_irq();
-  MutexName = osMutexGetName(id);
-  __enable_irq();
-  ASSERT_TRUE (strcmp(MutexName, name) != 0U);
 
   /* Call osMutexGetName from ISR */
   TST_IRQHandler = Irq_osMutexGetName_1;
@@ -465,7 +451,6 @@ void Irq_osMutexGetName_1 (void) {
 \brief Test case: TC_osMutexAcquire_1
 \details
   - Call osMutexAcquire to acquire the mutex from the running thread
-  - Call osMutexAcquire with masked interrupts
   - Call osMutexAcquire from ISR
   - Call osMutexAcquire with null mutex object
 */
@@ -489,12 +474,6 @@ void TC_osMutexAcquire_1 (void) {
   /* Create a mutex object */
   id = osMutexNew (NULL);
   ASSERT_TRUE(id != NULL);
-
-  /* Call osMutexAcquire with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osMutexAcquire (id, 0U);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osMutexAcquire from ISR */
   TST_IRQHandler = Irq_osMutexAcquire_1;
@@ -591,7 +570,6 @@ void Th_osMutexAcquire_2 (void *arg) {
 \details
   - Call osMutexRelease to release acquired mutex
   - Call osMutexRelease to release mutex that was not acquired
-  - Call osMutexRelease with masked interrupts
   - Call osMutexRelease from ISR
   - Call osMutexRelease with null mutex object
 */
@@ -622,12 +600,6 @@ void TC_osMutexRelease_1 (void) {
 
   /* Call osMutexAcquire to acquire mutex */
   ASSERT_TRUE (osMutexAcquire(id, osWaitForever) == osOK);
-
-  /* Call osMutexRelease with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osMutexRelease (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osMutexRelease from ISR */
   TST_IRQHandler = Irq_osMutexRelease_1;
@@ -662,7 +634,6 @@ void Irq_osMutexRelease_1 (void) {
 \details
   - Call osMutexGetOwner when the mutex is not locked
   - Call osMutexGetOwner when the mutex is locked
-  - Call osMutexGetOwner with masked interrupts
   - Call osMutexGetOwner from ISR
   - Call osMutexGetOwner with null object
 */
@@ -682,12 +653,6 @@ void TC_osMutexGetOwner_1 (void) {
 
   /* Call osMutexGetOwner when the mutex is locked */
   ASSERT_TRUE (osMutexGetOwner (id) == osThreadGetId());
-
-  /* Call osMutexGetOwner with masked interrupts */
-  __disable_irq();
-  ThreadId = osMutexGetOwner (id);
-  __enable_irq();
-  ASSERT_TRUE (ThreadId == NULL);
 
   /* Call osMutexGetOwner from ISR */
   TST_IRQHandler = Irq_osMutexGetOwner_1;
@@ -721,7 +686,6 @@ void Irq_osMutexGetOwner_1 (void) {
 \brief Test case: TC_osMutexDelete_1
 \details
   - Call osMutexDelete to delete a mutex
-  - Call osMutexDelete with masked interrupts
   - Call osMutexDelete from ISR
   - Call osMutexDelete with null object
 */
@@ -739,12 +703,6 @@ void TC_osMutexDelete_1 (void) {
   /* Create a mutex object */
   id = osMutexNew (NULL);
   ASSERT_TRUE (id != NULL);
-
-  /* Call osMutexDelete with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osMutexDelete (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osMutexDelete from ISR */
   TST_IRQHandler = Irq_osMutexDelete_1;

--- a/Source/RV2_Semaphore.c
+++ b/Source/RV2_Semaphore.c
@@ -117,7 +117,6 @@ The test cases check the osSemaphore* functions.
   - Call osSemaphoreNew to create a binary semaphore object with initial token set
   - Call osSemaphoreNew to create a counting semaphore object with initial token count cleared
   - Call osSemaphoreNew to create a counting semaphore object with initial token count set to max count={UINT8_MAX, UINT16_MAX, UINT32_MAX}
-  - Call osSemaphoreNew with masked interrupts
   - Call osSemaphoreNew from ISR
 */
 void TC_osSemaphoreNew_1 (void) {
@@ -163,12 +162,6 @@ void TC_osSemaphoreNew_1 (void) {
 
   /* Delete created semaphore */
   ASSERT_TRUE (osSemaphoreDelete(id) == osOK);
-
-  /* Call osSemaphoreNew with masked interrupts */
-  __disable_irq();
-  SemaphoreId = osSemaphoreNew (1U, 1U, NULL);
-  __enable_irq();
-  ASSERT_TRUE (SemaphoreId == NULL);
 
   /* Call osSemaphoreNew from ISR */
   TST_IRQHandler = Irq_osSemaphoreNew_1;
@@ -239,7 +232,6 @@ void TC_osSemaphoreNew_3 (void) {
   - Call osSemaphoreGetName to retrieve a name of an unnamed semaphore
   - Call osSemaphoreGetName to retrieve a name of a semaphore with assigned name
   - Call osSemaphoreGetName with valid object
-  - Call osSemaphoreGetName with masked interrupts
   - Call osSemaphoreGetName from ISR
   - Call osSemaphoreGetName with null object
 */
@@ -268,12 +260,6 @@ void TC_osSemaphoreGetName_1 (void) {
 
   /* Call osSemaphoreGetName to retrieve a name of a semaphore with assigned name */
   ASSERT_TRUE (strcmp(osSemaphoreGetName(id), name) == 0U);
-
-  /* Call osSemaphoreGetName with masked interrupts */
-  __disable_irq();
-  SemaphoreName = osSemaphoreGetName(id);
-  __enable_irq();
-  ASSERT_TRUE (strcmp(SemaphoreName, name) != 0U);
 
   /* Call osSemaphoreGetName from ISR */
   TST_IRQHandler = Irq_osSemaphoreGetName_1;
@@ -305,7 +291,6 @@ void Irq_osSemaphoreGetName_1 (void) {
 \details
   - Call osSemaphoreAcquire to acquire binary semaphore
   - Call osSemaphoreAcquire to acquire counting semaphore
-  - Call osSemaphoreAcquire with masked interrupts (non-zero timeout)
   - Call osSemaphoreAcquire from ISR (non-zero timeout)
   - Call osSemaphoreAcquire with null semaphore object
 */
@@ -339,12 +324,6 @@ void TC_osSemaphoreAcquire_1 (void) {
   id = osSemaphoreNew (1U, 1U, NULL);
   ASSERT_TRUE(id != NULL);
 
-  /* Call osSemaphoreAcquire with masked interrupts (non-zero timeout) */
-  __disable_irq();
-  Isr_osStatus = osSemaphoreAcquire (id, osWaitForever);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorParameter);
-
   /* Call osSemaphoreAcquire from ISR (non-zero timeout) */
   TST_IRQHandler = Irq_osSemaphoreAcquire_1;
   Isr_osStatus = osOK;
@@ -377,7 +356,6 @@ void Irq_osSemaphoreAcquire_1 (void) {
   - Call osSemaphoreRelease to release acquired counting semaphore
   - Call osSemaphoreRelease to release binary semaphore that was not acquired
   - Call osSemaphoreRelease to release counting semaphore that was not acquired
-  - Call osSemaphoreRelease with masked interrupts
   - Call osSemaphoreRelease from ISR
   - Call osSemaphoreRelease with null semaphore object
 */
@@ -442,15 +420,6 @@ void TC_osSemaphoreRelease_1 (void) {
   /* Call osSemaphoreAcquire to acquire semaphore */
   ASSERT_TRUE (osSemaphoreAcquire(id, osWaitForever) == osOK);
 
-  /* Call osSemaphoreRelease with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osSemaphoreRelease (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osOK);
-
-  /* Call osSemaphoreAcquire to acquire semaphore */
-  ASSERT_TRUE (osSemaphoreAcquire(id, osWaitForever) == osOK);
-
   /* Call osSemaphoreRelease from ISR */
   TST_IRQHandler = Irq_osSemaphoreRelease_1;
   Isr_osStatus = osError;
@@ -481,7 +450,6 @@ void Irq_osSemaphoreRelease_1 (void) {
 \details
   - Call osSemaphoreGetCount to get token count of an initialized semaphore
   - Call osSemaphoreGetCount to get token count of an acquired semaphore
-  - Call osSemaphoreGetCount with masked interrupts
   - Call osSemaphoreGetCount from ISR
   - Call osSemaphoreGetCount with a null object id
 */
@@ -509,12 +477,6 @@ void TC_osSemaphoreGetCount_1 (void) {
   for (i = 0U; i < MAX_SEMAPHORE_TOKEN_CNT; i++) {
     osSemaphoreRelease (id);
   }
-
-  /* Call osSemaphoreGetCount with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osSemaphoreGetCount (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == MAX_SEMAPHORE_TOKEN_CNT);
 
   /* Call osSemaphoreGetCount from ISR */
   TST_IRQHandler = Irq_osSemaphoreGetCount_1;
@@ -545,7 +507,6 @@ void Irq_osSemaphoreGetCount_1 (void) {
 \brief Test case: TC_osSemaphoreDelete_1
 \details
   - Call osSemaphoreDelete to delete a semaphore
-  - Call osSemaphoreDelete with masked interrupts
   - Call osSemaphoreDelete from ISR
   - Call osSemaphoreDelete with null object
 */
@@ -563,12 +524,6 @@ void TC_osSemaphoreDelete_1 (void) {
   /* Create a semaphore object */
   id = osSemaphoreNew (1U, 1U, NULL);
   ASSERT_TRUE (id != NULL);
-
-  /* Call osSemaphoreDelete with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osSemaphoreDelete (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osSemaphoreDelete from ISR */
   TST_IRQHandler = Irq_osSemaphoreDelete_1;

--- a/Source/RV2_Thread.c
+++ b/Source/RV2_Thread.c
@@ -183,7 +183,6 @@ The test cases check the osThread* functions.
 \details
   - Call osThreadNew to create a thread
   - Call osThreadNew with null thread function
-  - Call osThreadNew with masked interrupts
   - Call osThreadNew from ISR
 */
 void TC_osThreadNew_1 (void) {
@@ -199,12 +198,6 @@ void TC_osThreadNew_1 (void) {
 
   /* Call osThreadNew with null thread function */
   ASSERT_TRUE (osThreadNew (NULL, NULL, NULL) == NULL);
-
-  /* Call osThreadNew with masked interrupts */
-  __disable_irq();
-  ThreadId = osThreadNew (Th_Run, NULL, NULL);
-  __enable_irq();
-  ASSERT_TRUE (ThreadId == NULL);
 
   /* Call osThreadNew from ISR */
   TST_IRQHandler = Irq_osThreadNew_1;
@@ -394,7 +387,6 @@ void Th_Arg (void *arg) {
   - Call osThreadGetName to retrieve a name of an unnamed thread
   - Call osThreadGetName to retrieve a name of a thread with assigned name
   - Call osThreadGetName with valid object
-  - Call osThreadGetName with masked interrupts
   - Call osThreadGetName from ISR
   - Call osThreadGetName with null object
 */
@@ -423,12 +415,6 @@ void TC_osThreadGetName_1 (void) {
 
   /* Call osThreadGetName to retrieve a name of a thread with assigned name */
   ASSERT_TRUE (strcmp(osThreadGetName(id), name) == 0U);
-
-  /* Call osThreadGetName with masked interrupts */
-  __disable_irq();
-  ThreadName = osThreadGetName(id);
-  __enable_irq();
-  ASSERT_TRUE (strcmp(ThreadName, name) != 0U);
 
   /* Call osThreadGetName from ISR */
   TST_IRQHandler = Irq_osThreadGetName_1;
@@ -459,7 +445,6 @@ void Irq_osThreadGetName_1 (void) {
 \brief Test case: TC_osThreadGetId_1
 \details
   - Call osThreadGetId from multiple threads that exist at the same time
-  - Call osThreadGetId with masked interrupts
   - Call osThreadGetId from ISR
 */
 void TC_osThreadGetId_1 (void) {
@@ -487,14 +472,6 @@ void TC_osThreadGetId_1 (void) {
   for (i = 0U; i < MIN_THREAD_NUM; i++) {
     ASSERT_TRUE (thread_id[0][i] == thread_id[1][i]);
   }
-
-  id = osThreadGetId();
-
-  /* Call osThreadGetId with masked interrupts */
-  __disable_irq();
-  Isr_osThreadId = osThreadGetId();
-  __enable_irq();
-  ASSERT_TRUE (Isr_osThreadId == id);
 
   /* Call osThreadGetId from ISR */
   TST_IRQHandler = Irq_osThreadGetId_1;
@@ -533,7 +510,6 @@ void Irq_osThreadGetId_1 (void) {
 \details
   - Call osThreadGetState to retrieve the state of a running thread
   - Call osThreadGetState to retrieve the state of a ready thread
-  - Call osThreadGetState with masked interrupts
   - Call osThreadGetState from ISR
   - Call osThreadGetState to retrieve the state of a terminated thread
   - Call osThreadGetState with null object
@@ -556,12 +532,6 @@ void TC_osThreadGetState_1 (void) {
 
   /* Call osThreadGetState to retrieve the state of a ready thread */
   ASSERT_TRUE (osThreadGetState(id) == osThreadReady);
-
-  /* Call osThreadGetState with masked interrupts */
-  __disable_irq();
-  Isr_osThreadState = osThreadGetState(id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osThreadState == osThreadError);
 
   /* Call osThreadGetState from ISR */
   TST_IRQHandler = Irq_osThreadGetState_1;
@@ -745,7 +715,6 @@ void TC_osThreadSetPriority_1 (void) {
 \details
   - Call osThreadSetPriority with priority lower than osPriorityIdle
   - Call osThreadSetPriority with priority higher than osPriorityISR
-  - Call osThreadSetPriority with masked interrupts
   - Call osThreadSetPriority from ISR
   - Call osThreadSetPriority with null object
 */
@@ -763,12 +732,6 @@ void TC_osThreadSetPriority_2 (void) {
 
   /* Call osThreadSetPriority with priority higher than osPriorityISR */
   ASSERT_TRUE (osThreadSetPriority (id, (osPriority_t)(osPriorityISR + 1U)) == osErrorParameter);
-
-  /* Call osThreadSetPriority with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osThreadSetPriority(id, osPriorityBelowNormal);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osThreadSetPriority from ISR */
   TST_IRQHandler = Irq_osThreadSetPriority_2;
@@ -799,7 +762,6 @@ void Irq_osThreadSetPriority_2 (void) {
 \brief Test case: TC_osThreadGetPriority_1
 \details
   - Call osThreadGetPriority to retrieve priority of a running thread
-  - Call osThreadGetPriority with masked interrupts
   - Call osThreadGetPriority from ISR
   - Call osThreadGetPriority with null object
 */
@@ -811,12 +773,6 @@ void TC_osThreadGetPriority_1 (void) {
 
   /* Call osThreadGetPriority to retrieve priority of a running thread */
   ASSERT_TRUE (osThreadGetPriority(id) == osPriorityNormal);
-
-  /* Call osThreadGetPriority with masked interrupts */
-  __disable_irq();
-  Isr_osPriority = osThreadGetPriority(id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osPriority == osPriorityError);
 
   /* Call osThreadGetPriority from ISR */
   TST_IRQHandler = Irq_osThreadGetPriority_1;
@@ -844,19 +800,12 @@ void Irq_osThreadGetPriority_1 (void) {
 \brief Test case: TC_osThreadYield_1
 \details
   - Call osThreadYield with no thread in state 'Ready'
-  - Call osThreadYield with masked interrupts
   - Call osThreadYield from ISR
 */
 void TC_osThreadYield_1 (void) {
 #if (TC_OSTHREADYIELD_1_EN)
   /* Call osThreadYield with no thread in state 'Ready' */
   ASSERT_TRUE(osThreadYield() == osOK);
-
-  /* Call osThreadYield with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osThreadYield();
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osThreadYield from ISR */
   TST_IRQHandler = Irq_osThreadYield_1;
@@ -881,7 +830,6 @@ void Irq_osThreadYield_1 (void) {
 \details
   - Call osThreadSuspend to suspend a thread when there is at least one other thread 'Ready'
   - Call osThreadSuspend to suspend a child thread which is in 'Ready' state
-  - Call osThreadSuspend with masked interrupts
   - Call osThreadSuspend from ISR
   - Call osThreadSuspend with null object
 */
@@ -927,12 +875,6 @@ void TC_osThreadSuspend_1 (void) {
   cnt = 0U;
   id = osThreadNew (Th_osThreadSuspend_1, &cnt, &attr);
   ASSERT_TRUE(id != NULL);
-
-  /* Call osThreadSuspend with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osThreadSuspend(id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osThreadSuspend from ISR */
   TST_IRQHandler = Irq_osThreadSuspend_1;
@@ -985,7 +927,6 @@ void Irq_osThreadSuspend_1 (void) {
 \brief Test case: TC_osThreadResume_1
 \details
   - Call osThreadResume to resume suspended thread
-  - Call osThreadResume with masked interrupts
   - Call osThreadResume from ISR
   - Call osThreadResume with null object
 */
@@ -1021,12 +962,6 @@ void TC_osThreadResume_1 (void) {
 
   /* Suspend created thread */
   ASSERT_TRUE (osThreadSuspend(id) == osOK);
-
-  /* Call osThreadResume with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osThreadResume(id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osThreadResume from ISR */
   TST_IRQHandler = Irq_osThreadResume_1;
@@ -1122,7 +1057,6 @@ void TC_osThreadDetach_1 (void) {
 \brief Test case: TC_osThreadDetach_2
 \details
   - Call osThreadDetach with a detached thread
-  - Call osThreadDetach with masked interrupts
   - Call osThreadDetach from ISR
   - Call osThreadDetach with null object
 */
@@ -1137,12 +1071,6 @@ void TC_osThreadDetach_2 (void) {
 
   /* Call osThreadDetach with a detached thread */
   ASSERT_TRUE (osThreadDetach(id) == osErrorResource);
-
-  /* Call osThreadDetach with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osThreadDetach (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osThreadDetach from ISR */
   TST_IRQHandler = Irq_osThreadDetach_2;
@@ -1291,7 +1219,6 @@ void Th_Child_3 (void *arg) {
   - Call osThreadJoin with null object
   - Call osThreadJoin with a running thread
   - Call osThreadJoin with wrong object id
-  - Call osThreadJoin with masked interrupts
   - Call osThreadJoin from ISR
   - Call osThreadJoin with a joinable running thread
   - Call osThreadJoin with a joinable terminated thread
@@ -1316,12 +1243,6 @@ void TC_osThreadJoin_2 (void) {
   mid = osMutexNew (NULL);
   ASSERT_TRUE (osThreadJoin(mid) == osErrorParameter);
   osMutexDelete (mid);
-
-  /* Call osThreadJoin with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osThreadJoin(tid);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osThreadJoin from ISR */
   TST_IRQHandler = Irq_osThreadJoin_2;
@@ -1423,6 +1344,7 @@ void Th_osThreadExit_1 (void *arg) {
 \details
   - Call osThreadTerminate to terminate thread in state 'Ready'
   - Call osThreadTerminate to terminate thread in state 'Blocked' (delayed)
+  - Call osThreadTerminate from ISR
 */
 void TC_osThreadTerminate_1 (void) {
 #if (TC_OSTHREADTERMINATE_1_EN)
@@ -1464,12 +1386,6 @@ void TC_osThreadTerminate_1 (void) {
   id = osThreadNew (Th_osThreadTerminate_1, NULL, &attr);
   ASSERT_TRUE(id != NULL);
 
-  /* Call osThreadTerminate with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osThreadTerminate(id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
-
   /* Call osThreadTerminate from ISR */
   TST_IRQHandler = Irq_osThreadTerminate_1;
   Isr_osStatus = osOK;
@@ -1509,7 +1425,6 @@ void Irq_osThreadTerminate_1 (void) {
 \details
   - Call osThreadGetStackSize to retrieve the stack size of a running thread
   - Call osThreadGetStackSize to retrieve the stack size of a 'Ready' thread
-  - Call osThreadGetStackSize with masked interrupts
   - Call osThreadGetStackSize from ISR
   - Call osThreadGetStackSize with null object id
 */
@@ -1528,12 +1443,6 @@ void TC_osThreadGetStackSize_1 (void) {
 
   /* Call osThreadGetStackSize to retrieve the stack size of a 'Ready' thread */
   ASSERT_TRUE(osThreadGetStackSize(id) == 128U);
-
-  /* Call osThreadGetStackSize with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osThreadGetStackSize(id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == 0U);
 
   /* Call osThreadGetStackSize from ISR */
   TST_IRQHandler = Irq_osThreadGetStackSize_1;
@@ -1566,7 +1475,6 @@ void Irq_osThreadGetStackSize_1 (void) {
 \details
   - Call osThreadGetStackSpace to retrieve the unused stack space of a running thread
   - Call osThreadGetStackSpace to retrieve the unused stack space of a ready thread
-  - Call osThreadGetStackSpace with masked interrupts
   - Call osThreadGetStackSpace from ISR
   - Call osThreadGetStackSpace with null object
 */
@@ -1592,12 +1500,6 @@ void TC_osThreadGetStackSpace_1 (void) {
   ASSERT_TRUE (size > 0U);
 
   osThreadTerminate (id);
-
-  /* Call osThreadGetStackSpace with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osThreadGetStackSpace(id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == 0U);
 
   /* Call osThreadGetStackSpace from ISR */
   TST_IRQHandler = Irq_osThreadGetStackSpace_1;
@@ -1629,7 +1531,6 @@ void Irq_osThreadGetStackSpace_1 (void) {
 \brief Test case: TC_osThreadGetCount_1
 \details
   - Call osThreadGetCount to retrieve the number of active threads
-  - Call osThreadGetCount with masked interrupts
   - Call osThreadGetCount from ISR
 */
 void TC_osThreadGetCount_1 (void) {
@@ -1658,12 +1559,6 @@ void TC_osThreadGetCount_1 (void) {
   /* Terminate threads */
   osThreadTerminate (id[0]);
   osThreadTerminate (id[1]);
-
-  /* Call osThreadGetCount with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osThreadGetCount();
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == 0U);
 
   /* Call osThreadGetCount from ISR */
   TST_IRQHandler = Irq_osThreadGetCount_1;
@@ -1699,7 +1594,6 @@ void Irq_osThreadGetCount_1 (void) {
 \brief Test case: TC_osThreadEnumerate_1
 \details
   - Call osThreadEnumerate to retrieve IDs of all active threads
-  - Call osThreadEnumerate with masked interrupts
   - Call osThreadEnumerate from ISR
 */
 void TC_osThreadEnumerate_1 (void) {
@@ -1744,12 +1638,6 @@ void TC_osThreadEnumerate_1 (void) {
   /* Terminate threads */
   osThreadTerminate (id[0]);
   osThreadTerminate (id[1]);
-
-  /* Call osThreadEnumerate with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osThreadEnumerate(id_enum, 10U);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == 0U);
 
   /* Call osThreadEnumerate from ISR */
   TST_IRQHandler = Irq_osThreadEnumerate_1;

--- a/Source/RV2_Timer.c
+++ b/Source/RV2_Timer.c
@@ -99,7 +99,6 @@ The test cases check the osTimer* functions.
 \details
   - Call osTimerNew to create a timer object of type osTimerOnce
   - Call osTimerNew to create a timer object of type osTimerPeriodic
-  - Call osTimerNew with masked interrupts
   - Call osTimerNew from ISR
   - Call osTimerNew with null timer function
 */
@@ -120,12 +119,6 @@ void TC_osTimerNew_1 (void) {
 
   /* Delete created timer */
   ASSERT_TRUE (osTimerDelete(id) == osOK);
-
-  /* Call osTimerNew with masked interrupts */
-  __disable_irq();
-  TimerId = osTimerNew (TimCb_Dummy, osTimerOnce, NULL, NULL);
-  __enable_irq();
-  ASSERT_TRUE (TimerId == NULL);
 
   /* Call osTimerNew from ISR */
   TST_IRQHandler = Irq_osTimerNew_1;
@@ -199,7 +192,6 @@ void TC_osTimerNew_3 (void) {
   - Call osTimerGetName to retrieve a name of an unnamed timer
   - Call osTimerGetName to retrieve a name of a timer with assigned name
   - Call osTimerGetName with valid object
-  - Call osTimerGetName with masked interrupts
   - Call osTimerGetName from ISR
   - Call osTimerGetName with null object
 */
@@ -228,12 +220,6 @@ void TC_osTimerGetName_1 (void) {
 
   /* Call osTimerGetName to retrieve a name of a timer with assigned name */
   ASSERT_TRUE (strcmp(osTimerGetName(tid), name) == 0U);
-
-  /* Call osTimerGetName with masked interrupts */
-  __disable_irq();
-  TimerName = osTimerGetName(tid);
-  __enable_irq();
-  ASSERT_TRUE (strcmp(TimerName, name) != 0U);
 
   /* Call osTimerGetName from ISR */
   TST_IRQHandler = Irq_osTimerGetName_1;
@@ -265,7 +251,6 @@ void Irq_osTimerGetName_1 (void) {
 \details
   - Call osTimerStart to start the one-shot timer
   - Call osTimerStart to start the periodic timer
-  - Call osTimerStart with masked interrupts
   - Call osTimerStart from ISR
   - Call osTimerStart with invalid ticks value
   - Call osTimerStart with null object
@@ -316,12 +301,6 @@ void TC_osTimerStart_1 (void) {
   /* Create a one-shot timer */
   id = osTimerNew (&TimCb_Oneshot, osTimerOnce, &arg, NULL);
   ASSERT_TRUE (id != NULL);
-
-  /* Call osTimerStart with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osTimerStart (id, 10U);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osTimerStart from ISR */
   TST_IRQHandler = Irq_osTimerStart_1;
@@ -410,7 +389,6 @@ void TimCb_osTimerStart_2  (void *arg) {
 \details
   - Call osTimerStop to stop the one-shoot timer
   - Call osTimerStop to stop the periodic timer
-  - Call osTimerStop with masked interrupts
   - Call osTimerStop from ISR
   - Call osTimerStop with null object
 */
@@ -453,12 +431,6 @@ void TC_osTimerStop_1 (void) {
 
   /* Start the timer */
   osTimerStart (id, 10U);
-
-  /* Call osTimerStop with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osTimerStop (id);
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
-  __enable_irq();
 
   /* Call osTimerStop from ISR */
   TST_IRQHandler = Irq_osTimerStop_1;
@@ -539,7 +511,6 @@ void TC_osTimerStop_2 (void) {
   - Call osTimerIsRunning to check whether a one-shoot timer is stopped
   - Call osTimerIsRunning to check whether a periodic timer is running
   - Call osTimerIsRunning to check whether a periodic timer is stopped
-  - Call osTimerIsRunning with masked interrupts
   - Call osTimerIsRunning from ISR
   - Call osTimerIsRunning with null object
 */
@@ -592,12 +563,6 @@ void TC_osTimerIsRunning_1 (void) {
   id = osTimerNew (&TimCb_Oneshot, osTimerOnce, &arg, NULL);
   ASSERT_TRUE (id != NULL);
 
-  /* Call osTimerIsRunning with masked interrupts */
-  __disable_irq();
-  Isr_u32 = osTimerIsRunning (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_u32 == 0U);
-
   /* Call osTimerIsRunning from ISR */
   TST_IRQHandler = Irq_osTimerIsRunning_1;
   Isr_u32 = 1U;
@@ -630,7 +595,6 @@ void Irq_osTimerIsRunning_1 (void) {
   - Call osTimerDelete to delete running one-shoot timer
   - Call osTimerDelete to delete stopped periodic timer
   - Call osTimerDelete to delete running periodic timer
-  - Call osTimerDelete with masked interrupts
   - Call osTimerDelete from ISR
   - Call osTimerDelete with null object
 */
@@ -678,12 +642,6 @@ void TC_osTimerDelete_1 (void) {
   /* Create one shot timer */
   id = osTimerNew (&TimCb_Oneshot, osTimerOnce, &arg, NULL);
   ASSERT_TRUE (id != NULL);
-
-  /* Call osTimerDelete with masked interrupts */
-  __disable_irq();
-  Isr_osStatus = osTimerDelete (id);
-  __enable_irq();
-  ASSERT_TRUE (Isr_osStatus == osErrorISR);
 
   /* Call osTimerDelete from ISR */
   TST_IRQHandler = Irq_osTimerDelete_1;


### PR DESCRIPTION
CMSIS-RTOS2 API does not specify the behavior when interrupts are disabled.