### PR TITLE
Fix UART Control for FPGA

### DIFF
--- a/Layer/App/Validation_FreeRTOS/retarget_stdio.c
+++ b/Layer/App/Validation_FreeRTOS/retarget_stdio.c
@@ -59,7 +59,7 @@ int stdio_init (void) {
                              USART_BAUDRATE);
   if (status != ARM_DRIVER_OK) return (-1);
  
-  status = ptrUSART->Control(ARM_USART_CONTROL_RX, 1);
+  status = ptrUSART->Control(ARM_USART_CONTROL_TX, 1);
   if (status != ARM_DRIVER_OK) return (-1);
  
   return (0);

--- a/Layer/App/Validation_RTX5/retarget_stdio.c
+++ b/Layer/App/Validation_RTX5/retarget_stdio.c
@@ -59,7 +59,7 @@ int stdio_init (void) {
                              USART_BAUDRATE);
   if (status != ARM_DRIVER_OK) return (-1);
  
-  status = ptrUSART->Control(ARM_USART_CONTROL_RX, 1);
+  status = ptrUSART->Control(ARM_USART_CONTROL_TX, 1);
   if (status != ARM_DRIVER_OK) return (-1);
  
   return (0);


### PR DESCRIPTION
Running RTOS validation on MPS2 FPGA was looping forever in USART0_GetTxCount (no issue on VHT)