### PR TITLE
Change the order of message queue processing while in interrupt handler

### DIFF
--- a/Source/RV2_MessageQueue.c
+++ b/Source/RV2_MessageQueue.c
@@ -339,6 +339,9 @@ void Irq_osMessageQueuePut_2 (void) {
   uint32_t cnt;
   uint32_t msg;
 
+  /* Check that the number of available message slots is correct */
+  ASSERT_TRUE (osMessageQueueGetSpace (MessageQueueId) == MSGQ_CNT);
+
   /* Fill the message queue with messages */
   msg = 1U;
   cnt = MSGQ_CNT;
@@ -347,8 +350,6 @@ void Irq_osMessageQueuePut_2 (void) {
     ASSERT_TRUE (osMessageQueuePut (MessageQueueId, &msg, 0U, 0U) == osOK);
     msg++;
   }
-  /* Check that the message queue is full */
-  ASSERT_TRUE (osMessageQueueGetSpace (MessageQueueId) == 0U);
 
   /* Call osMessageQueuePut when the message queue is full */
   ASSERT_TRUE (osMessageQueuePut (MessageQueueId, &msg, 0U, 0U) == osErrorResource);
@@ -505,6 +506,9 @@ void Irq_osMessageQueueGet_2 (void) {
   uint32_t msg;
   uint32_t msg_out;
 
+  /* Check that the number of enqueued messages is correct */
+  ASSERT_TRUE (osMessageQueueGetCount(MessageQueueId) == MSGQ_CNT);
+
   msg = 1U;
   cnt = MSGQ_CNT;
 
@@ -513,8 +517,6 @@ void Irq_osMessageQueueGet_2 (void) {
     ASSERT_TRUE (msg == msg_out);
     msg++;
   }
-  /* Check that the message queue is empty */
-  ASSERT_TRUE (osMessageQueueGetSpace (MessageQueueId) == MSGQ_CNT);
 
   /* Call osMessageQueueGet when the message queue is empty */
   ASSERT_TRUE (osMessageQueueGet (MessageQueueId, &msg_out, NULL, 0U) == osErrorResource);


### PR DESCRIPTION
- check available space in message queue, before osMessageQueuePut is called
- check number of enqueued messages in queue, before osMessageQueueGet is called