### PR TITLE
Update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: Open-CMSIS-Pack/gen-pack-action@main
         with:
-          doxygen-version: 1.9.2                                  # default
+          doxygen-version: 1.9.6                                  # default
           packchk-version: 1.3.95                                 # default
           gen-doc-script: ./DoxyGen/gen_doc.sh                    # skipped by default
           check-links-script: ./DoxyGen/check_links.sh            # skipped by default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pack:
     name: Generate pack
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cmsis_rv2.yml
+++ b/.github/workflows/cmsis_rv2.yml
@@ -22,7 +22,7 @@ jobs:
         compiler: [AC6, GCC, Clang]
         rtos: [RTX5, FreeRTOS]
     
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt-get install libpython3.9 libtinfo5
+          sudo apt-get install libpython3.9 libtinfo6
 
       - name: Python requirements
         run: |


### PR DESCRIPTION
This PR updates the GitHub Actions runner from ubuntu-20.04 to ubuntu-22.04.